### PR TITLE
🔀 :: (#35) - 로그인 페이지 디자인 변경사항 적용

### DIFF
--- a/presentation/src/main/java/com/sms/presentation/main/ui/login/LoginActivity.kt
+++ b/presentation/src/main/java/com/sms/presentation/main/ui/login/LoginActivity.kt
@@ -22,7 +22,7 @@ class LoginActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
         observeEvent()
         setContent {
-            LoginScreen {
+            LoginScreen(context = this@LoginActivity) {
                 setContent {
                     GAuthSigninWebView(
                         clientId = BuildConfig.CLIENT_ID,

--- a/presentation/src/main/java/com/sms/presentation/main/ui/login/component/LoginScreen.kt
+++ b/presentation/src/main/java/com/sms/presentation/main/ui/login/component/LoginScreen.kt
@@ -1,13 +1,14 @@
 package com.sms.presentation.main.ui.login.component
 
+import android.content.Context
 import androidx.compose.foundation.layout.Box
 import androidx.compose.runtime.Composable
 
 @Composable
-fun LoginScreen(onClick: () -> Unit) {
+fun LoginScreen(context: Context, onClick: () -> Unit) {
     Box {
         LoginPageBackGround()
-        TopComponent()
+        TopComponent(context)
         LoginButton {
             onClick()
         }

--- a/presentation/src/main/java/com/sms/presentation/main/ui/login/component/TopComponent.kt
+++ b/presentation/src/main/java/com/sms/presentation/main/ui/login/component/TopComponent.kt
@@ -20,7 +20,7 @@ fun TopComponent() {
         ) {
             Spacer(modifier = Modifier.fillMaxHeight(0.15f))
             Text(
-                text = "Student\nManagement\nService",
+                text = "STUDENT\nMANAGEMENT\nSERVICE",
                 style = typography.headline1,
                 fontWeight = FontWeight(700),
                 color = colors.WHITE,

--- a/presentation/src/main/java/com/sms/presentation/main/ui/login/component/TopComponent.kt
+++ b/presentation/src/main/java/com/sms/presentation/main/ui/login/component/TopComponent.kt
@@ -1,5 +1,6 @@
 package com.sms.presentation.main.ui.login.component
 
+import android.content.Context
 import androidx.compose.foundation.layout.*
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
@@ -9,9 +10,10 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.msg.sms.design.theme.SMSTheme
+import com.sms.presentation.R
 
 @Composable
-fun TopComponent() {
+fun TopComponent(context: Context) {
     SMSTheme { colors, typography ->
         Column(
             modifier = Modifier
@@ -20,7 +22,7 @@ fun TopComponent() {
         ) {
             Spacer(modifier = Modifier.fillMaxHeight(0.15f))
             Text(
-                text = "STUDENT\nMANAGEMENT\nSERVICE",
+                text = context.getString(R.string.login_page_topcomponent_text_english),
                 style = typography.headline1,
                 fontWeight = FontWeight(700),
                 color = colors.WHITE,
@@ -28,7 +30,7 @@ fun TopComponent() {
             )
             Spacer(modifier = Modifier.size(12.dp))
             Text(
-                text = "학생 정보 통합관리 서비스",
+                text = context.getString(R.string.login_page_topcomponent_text_korean),
                 style = typography.title2,
                 fontWeight = FontWeight(600),
                 color = colors.N20

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -1,4 +1,6 @@
 <resources>
     <string name="title_activity_main">MainActivity</string>
     <string name="title_activity_login">LoginActivity</string>
+    <string name="login_page_topcomponent_text_english">STUDENT\nMANAGEMENT\nSERVICE</string>
+    <string name="login_page_topcomponent_text_korean">학생 정보 통합관리 서비스</string>
 </resources>


### PR DESCRIPTION
## 💡 개요
- 로그인 페이지 디자인 변경사항을 적용합니다.

## 📃 작업내용
<img width="515" alt="스크린샷 2023-04-27 오전 8 59 27" src="https://user-images.githubusercontent.com/80810303/234727125-0a1efc9c-2bb5-43a4-9013-31a71d4d2d4a.png">

## 🔀 변경사항
- 로그인 페이지 상단 컴포넌트의 텍스트를 전부 대문자로 변경했습니다.
