### PR TITLE
🔀 :: (#45) - create text field of design component

### DIFF
--- a/design-system/src/main/java/com/msg/sms/design/component/textfield/SmsTextField.kt
+++ b/design-system/src/main/java/com/msg/sms/design/component/textfield/SmsTextField.kt
@@ -4,27 +4,29 @@ import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.IconButton
 import androidx.compose.material.Text
 import androidx.compose.material.TextField
 import androidx.compose.material.TextFieldDefaults
 import androidx.compose.runtime.*
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
-import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.msg.sms.design.icon.DeleteButtonIcon
 import com.msg.sms.design.theme.SMSTheme
 
 @Composable
 fun SmsTextField(
-    modifier: Modifier,
-    isError: Boolean,
-    placeHolder: String,
+    modifier: Modifier = Modifier,
+    isError: Boolean = false,
+    placeHolder: String = "",
     readOnly: Boolean = true,
-    focusRequester: FocusRequester,
-    errorText: String,
+    focusRequester: FocusRequester = FocusRequester(),
+    errorText: String = "Error",
     onValueChange: (String) -> Unit = {}
 ) {
     var text by remember { mutableStateOf("") }
@@ -48,7 +50,12 @@ fun SmsTextField(
                     placeholderColor = colors.N30,
                     focusedBorderColor = colors.P2,
                     unfocusedBorderColor = colors.N10
-                )
+                ),
+                trailingIcon = {
+                    IconButton(onClick = { text = "" }) {
+                        DeleteButtonIcon()
+                    }
+                }
             )
             if (isError) {
                 Spacer(modifier = Modifier.height(8.dp))
@@ -56,4 +63,16 @@ fun SmsTextField(
             }
         }
     }
+}
+
+@Preview
+@Composable
+fun SmsTextFieldPre() {
+    SmsTextField(
+        modifier = Modifier
+            .height(48.dp)
+            .width(200.dp),
+        placeHolder = "Test",
+        isError = true
+    )
 }

--- a/design-system/src/main/java/com/msg/sms/design/component/textfield/SmsTextField.kt
+++ b/design-system/src/main/java/com/msg/sms/design/component/textfield/SmsTextField.kt
@@ -1,9 +1,20 @@
 package com.msg.sms.design.component.textfield
 
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Text
 import androidx.compose.material.TextField
+import androidx.compose.material.TextFieldDefaults
 import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.unit.dp
 import com.msg.sms.design.theme.SMSTheme
 
 @Composable
@@ -12,22 +23,37 @@ fun SmsTextField(
     isError: Boolean,
     placeHolder: String,
     readOnly: Boolean = true,
-    isFocus: Boolean = false,
+    focusRequester: FocusRequester,
+    errorText: String,
     onValueChange: (String) -> Unit = {}
 ) {
     var text by remember { mutableStateOf("") }
     SMSTheme { colors, typography ->
-        TextField(
-            value = text,
-            onValueChange = {
-                text = it
-                onValueChange(it)
-            },
-            placeholder = {
-                Text(text = placeHolder, style = typography.body1)
-            },
-            modifier = modifier,
-            textStyle = typography.body1,
-        )
+        Column {
+            TextField(
+                value = text,
+                onValueChange = {
+                    text = it
+                    onValueChange(it)
+                },
+                placeholder = {
+                    Text(text = placeHolder, style = typography.body1)
+                },
+                modifier = modifier
+                    .border(width = 1.dp, shape = RoundedCornerShape(8.dp), color = colors.N10)
+                    .focusRequester(focusRequester),
+                textStyle = typography.body1,
+                colors = TextFieldDefaults.outlinedTextFieldColors(
+                    backgroundColor = colors.N10,
+                    placeholderColor = colors.N30,
+                    focusedBorderColor = colors.P2,
+                    unfocusedBorderColor = colors.N10
+                )
+            )
+            if (isError) {
+                Spacer(modifier = Modifier.height(8.dp))
+                Text(text = errorText, color = colors.ERROR, style = typography.caption1)
+            }
+        }
     }
 }

--- a/design-system/src/main/java/com/msg/sms/design/component/textfield/SmsTextField.kt
+++ b/design-system/src/main/java/com/msg/sms/design/component/textfield/SmsTextField.kt
@@ -1,0 +1,33 @@
+package com.msg.sms.design.component.textfield
+
+import androidx.compose.material.Text
+import androidx.compose.material.TextField
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import com.msg.sms.design.theme.SMSTheme
+
+@Composable
+fun SmsTextField(
+    modifier: Modifier,
+    isError: Boolean,
+    placeHolder: String,
+    readOnly: Boolean = true,
+    isFocus: Boolean = false,
+    onValueChange: (String) -> Unit = {}
+) {
+    var text by remember { mutableStateOf("") }
+    SMSTheme { colors, typography ->
+        TextField(
+            value = text,
+            onValueChange = {
+                text = it
+                onValueChange(it)
+            },
+            placeholder = {
+                Text(text = placeHolder, style = typography.body1)
+            },
+            modifier = modifier,
+            textStyle = typography.body1,
+        )
+    }
+}

--- a/design-system/src/main/java/com/msg/sms/design/component/textfield/SmsTextField.kt
+++ b/design-system/src/main/java/com/msg/sms/design/component/textfield/SmsTextField.kt
@@ -7,13 +7,15 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.IconButton
+import androidx.compose.material.OutlinedTextField
 import androidx.compose.material.Text
-import androidx.compose.material.TextField
 import androidx.compose.material.TextFieldDefaults
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.msg.sms.design.icon.DeleteButtonIcon
@@ -30,9 +32,10 @@ fun SmsTextField(
     onValueChange: (String) -> Unit = {}
 ) {
     var text by remember { mutableStateOf("") }
+    val isFocused = remember { mutableStateOf(false) }
     SMSTheme { colors, typography ->
         Column {
-            TextField(
+            OutlinedTextField(
                 value = text,
                 onValueChange = {
                     text = it
@@ -42,14 +45,21 @@ fun SmsTextField(
                     Text(text = placeHolder, style = typography.body1)
                 },
                 modifier = modifier
-                    .border(width = 1.dp, shape = RoundedCornerShape(8.dp), color = colors.N10)
-                    .focusRequester(focusRequester),
+                    .focusRequester(focusRequester)
+                    .border(
+                        width = 1.dp,
+                        color = if (isFocused.value) colors.P2 else colors.N10,
+                        shape = RoundedCornerShape(8.dp)
+                    )
+                    .onFocusChanged {
+                        isFocused.value = it.isFocused
+                    },
                 textStyle = typography.body1,
                 colors = TextFieldDefaults.outlinedTextFieldColors(
                     backgroundColor = colors.N10,
                     placeholderColor = colors.N30,
-                    focusedBorderColor = colors.P2,
-                    unfocusedBorderColor = colors.N10
+                    focusedBorderColor = Color.Transparent,
+                    unfocusedBorderColor = Color.Transparent
                 ),
                 trailingIcon = {
                     IconButton(onClick = { text = "" }) {

--- a/design-system/src/main/java/com/msg/sms/design/component/textfield/SmsTextField.kt
+++ b/design-system/src/main/java/com/msg/sms/design/component/textfield/SmsTextField.kt
@@ -26,7 +26,7 @@ fun SmsTextField(
     modifier: Modifier = Modifier,
     isError: Boolean = false,
     placeHolder: String = "",
-    readOnly: Boolean = true,
+    readOnly: Boolean = false,
     focusRequester: FocusRequester = FocusRequester(),
     errorText: String = "Error",
     onValueChange: (String) -> Unit = {}
@@ -65,7 +65,8 @@ fun SmsTextField(
                     IconButton(onClick = { text = "" }) {
                         DeleteButtonIcon()
                     }
-                }
+                },
+                readOnly = readOnly
             )
             if (isError) {
                 Spacer(modifier = Modifier.height(8.dp))


### PR DESCRIPTION
## 💡 개요
텍스트 필드 컴포넌트를 생성합니다.

## 🎸 보기
옆에 아이콘 색 관련 이슈는 @khs3994 

https://github.com/GSM-MSG/SMS-Android/assets/82383983/53e90581-af44-4564-93af-1ee5bd2c4fda

