### PR TITLE
🔀 :: (#134) - 메인리스트 페이지에서 학생 수 뜨도록 처리

### DIFF
--- a/presentation/src/main/java/com/sms/presentation/main/ui/main/component/MainScreenTopBar.kt
+++ b/presentation/src/main/java/com/sms/presentation/main/ui/main/component/MainScreenTopBar.kt
@@ -2,6 +2,7 @@ package com.sms.presentation.main.ui.main.component
 
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Divider
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -12,42 +13,56 @@ import coil.compose.AsyncImage
 import com.msg.sms.design.icon.FilterButtonIcon
 import com.msg.sms.design.icon.SmsLogoIcon
 import com.msg.sms.design.modifier.smsClickable
+import com.msg.sms.design.theme.SMSTheme
 import com.sms.design_system.R
 
 @Composable
 fun MainScreenTopBar(
     profileImageUrl: String,
+    isScolled: Boolean,
     filterButtonOnClick: () -> Unit,
     profileButtonOnClick: () -> Unit
 ) {
-    Box(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(end = 12.dp, top = 3.5.dp, bottom = 3.5.dp)
-    ) {
-        SmsLogoIcon(
+    Column {
+        Box(
             modifier = Modifier
-                .width(100.dp)
-                .height(50.dp)
-                .align(Alignment.CenterStart)
-        )
-        Row(modifier = Modifier.align(Alignment.CenterEnd)) {
-            FilterButtonIcon(
+                .fillMaxWidth()
+                .padding(end = 12.dp, top = 3.5.dp, bottom = 3.5.dp)
+        ) {
+            SmsLogoIcon(
                 modifier = Modifier
-                    .smsClickable(onClick = filterButtonOnClick)
+                    .width(100.dp)
+                    .height(50.dp)
+                    .align(Alignment.CenterStart)
             )
-            Spacer(modifier = Modifier.width(16.dp))
-            AsyncImage(
-                model = profileImageUrl,
-                placeholder = painterResource(id = R.drawable.ic_profile_default),
-                error = painterResource(id = R.drawable.ic_profile_default),
-                contentDescription = "Profile Image",
-                modifier = Modifier
-                    .width(32.dp)
-                    .height(32.dp)
-                    .clip(RoundedCornerShape(20.dp))
-                    .smsClickable(onClick = profileButtonOnClick)
-            )
+            Row(modifier = Modifier.align(Alignment.CenterEnd)) {
+                FilterButtonIcon(
+                    modifier = Modifier
+                        .smsClickable(onClick = filterButtonOnClick)
+                )
+                Spacer(modifier = Modifier.width(16.dp))
+                AsyncImage(
+                    model = profileImageUrl,
+                    placeholder = painterResource(id = R.drawable.ic_profile_default),
+                    error = painterResource(id = R.drawable.ic_profile_default),
+                    contentDescription = "Profile Image",
+                    modifier = Modifier
+                        .width(32.dp)
+                        .height(32.dp)
+                        .clip(RoundedCornerShape(20.dp))
+                        .smsClickable(onClick = profileButtonOnClick)
+                )
+            }
+        }
+        SMSTheme { colors, _ ->
+            if (isScolled) {
+                Divider(
+                    modifier = Modifier
+                        .fillMaxWidth(),
+                    color = colors.N10,
+                    thickness = 1.dp
+                )
+            }
         }
     }
 }

--- a/presentation/src/main/java/com/sms/presentation/main/ui/main/component/StudentListComponent.kt
+++ b/presentation/src/main/java/com/sms/presentation/main/ui/main/component/StudentListComponent.kt
@@ -5,9 +5,11 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.Divider
+import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.msg.sms.design.theme.SMSTheme
 import com.msg.sms.domain.model.student.response.StudentModel
@@ -17,10 +19,31 @@ fun StudentListComponent(
     listState: LazyListState,
     progressState: Boolean,
     studentList: List<StudentModel>,
+    listTotalSize: Int,
     onItemClick: () -> Unit
 ) {
-    SMSTheme { colors, _ ->
+    SMSTheme { colors, typography ->
         LazyColumn(state = listState) {
+            item {
+                Row(
+                    modifier = Modifier.padding(start = 20.dp, top = 32.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Text(
+                        text = listTotalSize.toString(),
+                        style = typography.title1,
+                        fontWeight = FontWeight.Bold,
+                        color = colors.BLACK
+                    )
+                    Spacer(modifier = Modifier.width(4.dp))
+                    Text(
+                        text = "명",
+                        style = typography.title2,
+                        fontWeight = FontWeight.Bold,
+                        color = colors.N30
+                    )
+                }
+            }
             items(studentList.size) {
                 StudentListItem(
                     profileImageUrl = studentList[it].profileImg,

--- a/presentation/src/main/java/com/sms/presentation/main/ui/main/screen/MainScreen.kt
+++ b/presentation/src/main/java/com/sms/presentation/main/ui/main/screen/MainScreen.kt
@@ -34,6 +34,9 @@ fun MainScreen(
     val listTotalSize = remember {
         mutableStateOf(0)
     }
+    val isScrolled = remember {
+        mutableStateOf(false)
+    }
 
     LaunchedEffect("GetStudentList") {
         getStudentList(
@@ -46,6 +49,14 @@ fun MainScreen(
         )
     }
 
+    LaunchedEffect("isScrolled") {
+        snapshotFlow { listState.layoutInfo.visibleItemsInfo.first().index != 0 }
+            .collect {
+                if (isScrolled.value != it)
+                    isScrolled.value = it
+            }
+    }
+
     Column(
         modifier = Modifier
             .fillMaxSize()
@@ -53,6 +64,7 @@ fun MainScreen(
     ) {
         MainScreenTopBar(
             profileImageUrl = "",
+            isScolled = isScrolled.value,
             filterButtonOnClick = { /*TODO (KimHyunseung) : 필터 Screen으로 이동*/ },
             profileButtonOnClick = { /*TODO (KimHyunseung) : 마이페이지로 이동*/ }
         )

--- a/presentation/src/main/java/com/sms/presentation/main/ui/main/screen/MainScreen.kt
+++ b/presentation/src/main/java/com/sms/presentation/main/ui/main/screen/MainScreen.kt
@@ -1,6 +1,5 @@
 package com.sms.presentation.main.ui.main.screen
 
-import android.util.Log
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.rememberLazyListState
@@ -32,14 +31,17 @@ fun MainScreen(
     val progressState = remember {
         mutableStateOf(false)
     }
+    val listTotalSize = remember {
+        mutableStateOf(0)
+    }
 
     LaunchedEffect("GetStudentList") {
         getStudentList(
             viewModel = viewModel,
             progressState = { progressState.value = it },
-            onSuccess = {
-                Log.d("studentList", it.toString())
-                studentList.value += it
+            onSuccess = { list, size ->
+                studentList.value += list
+                listTotalSize.value = size
             }
         )
     }
@@ -54,12 +56,12 @@ fun MainScreen(
             filterButtonOnClick = { /*TODO (KimHyunseung) : 필터 Screen으로 이동*/ },
             profileButtonOnClick = { /*TODO (KimHyunseung) : 마이페이지로 이동*/ }
         )
-        Spacer(modifier = Modifier.height(16.dp))
         Box(modifier = Modifier.fillMaxSize()) {
             StudentListComponent(
                 listState = listState,
                 progressState = progressState.value,
-                studentList = studentList.value
+                studentList = studentList.value,
+                listTotalSize = listTotalSize.value
             ) {
                 //TODO (Kimhyunseung) : 디테일 페이지로 이동
             }
@@ -98,13 +100,13 @@ fun MainScreen(
 suspend fun getStudentList(
     viewModel: StudentListViewModel,
     progressState: (Boolean) -> Unit,
-    onSuccess: (List<StudentModel>) -> Unit
+    onSuccess: (studentList: List<StudentModel>, totalListSize: Int) -> Unit
 ) {
     viewModel.getStudentListResponse.collect { response ->
         when (response) {
             is Event.Success -> {
                 progressState(false)
-                onSuccess(response.data!!.content)
+                onSuccess(response.data!!.content, response.data.totalSize)
             }
             is Event.Loading -> {
                 progressState(true)


### PR DESCRIPTION
## 💡 개요
- 메인리스트 페이지에서 학생 수 뜨도록 처리

## 📃 작업내용
- 메인 리스트 맨 위 아이템에 학생 수가 뜨는 UI추가
- 스크롤 된 상태면 탑바 밑에 디바이더가 뜨도록 처리
![스크린샷 2023-06-12 오후 6 12 11](https://github.com/GSM-MSG/SMS-Android/assets/80810303/41a7624d-7cef-4af1-853c-37c94e403a2c) ![스크린샷 2023-06-12 오후 6 12 55](https://github.com/GSM-MSG/SMS-Android/assets/80810303/85f9afa4-b7e3-42ed-919f-e1510d3b1e6b)

