### PR TITLE
🔀 :: (#140) - 로그아웃, 회원탈퇴를 위한 바텀시트 UI제작

### DIFF
--- a/design-system/src/main/java/com/msg/sms/design/icon/SmsIcon.kt
+++ b/design-system/src/main/java/com/msg/sms/design/icon/SmsIcon.kt
@@ -214,3 +214,25 @@ fun ArrowUpWardIcon(
         modifier = modifier
     )
 }
+
+@Composable
+fun RedLogoutIcon(
+    modifier: Modifier = Modifier
+) {
+    Image(
+        painter = painterResource(id = R.drawable.ic_red_logout),
+        contentDescription = "Red Logout Button Icon",
+        modifier = modifier
+    )
+}
+
+@Composable
+fun RedWithdrawalIcon(
+    modifier: Modifier = Modifier
+) {
+    Image(
+        painter = painterResource(id = R.drawable.ic_red_withdrawal),
+        contentDescription = "Red Withdrawal Button Icon",
+        modifier = modifier
+    )
+}

--- a/design-system/src/main/res/drawable/ic_red_logout.xml
+++ b/design-system/src/main/res/drawable/ic_red_logout.xml
@@ -1,0 +1,16 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M19,21L12,21C10.895,21 10,20.105 10,19L10,5C10,3.895 10.895,3 12,3L19,3C20.105,3 21,3.895 21,5L21,19C21,20.105 20.105,21 19,21Z"
+      android:fillColor="#E1E2E4"/>
+  <path
+      android:pathData="M17,12L3,12M3,12L6,9M3,12L6,15"
+      android:strokeLineJoin="round"
+      android:strokeWidth="2"
+      android:fillColor="#00000000"
+      android:strokeColor="#F05252"
+      android:strokeLineCap="round"/>
+</vector>

--- a/design-system/src/main/res/drawable/ic_red_withdrawal.xml
+++ b/design-system/src/main/res/drawable/ic_red_withdrawal.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M7.5,6.5C7.5,4.015 9.515,2 12,2C14.485,2 16.5,4.015 16.5,6.5C16.5,8.985 14.485,11 12,11C9.515,11 7.5,8.985 7.5,6.5Z"
+      android:fillColor="#F05252"/>
+  <path
+      android:pathData="M3,18C3,15.239 5.239,13 8,13H16C18.761,13 21,15.239 21,18V20C21,21.105 20.105,22 19,22H5C3.895,22 3,21.105 3,20V18Z"
+      android:fillColor="#E1E2E4"/>
+</vector>

--- a/presentation/src/main/java/com/sms/presentation/main/ui/main/component/ModalBottomSheetItem.kt
+++ b/presentation/src/main/java/com/sms/presentation/main/ui/main/component/ModalBottomSheetItem.kt
@@ -1,32 +1,63 @@
 package com.sms.presentation.main.ui.main.component
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Text
-import androidx.compose.runtime.Composable
+import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.msg.sms.design.modifier.smsClickable
 import com.msg.sms.design.theme.SMSTheme
+import com.msg.sms.design.theme.color.LightColor
 
 @Composable
-fun ModalBottomSheetItem(text: String, icon: @Composable () -> Unit, onClick: () -> Unit) {
+fun ModalBottomSheetItem(
+    text: String,
+    icon: @Composable () -> Unit,
+    onClick: () -> Unit
+) {
+    var backgroundColor by remember {
+        mutableStateOf(Color.Transparent)
+    }
+
     SMSTheme { colors, typography ->
-        Row(
+        Box(
             modifier = Modifier
                 .fillMaxWidth()
-                .smsClickable(onClick = onClick),
-            verticalAlignment = Alignment.CenterVertically
+                .padding(horizontal = 16.dp)
+                .smsClickable(rippleEnabled = false, onClick = onClick)
+                .pointerInput(Unit) {
+                    detectTapGestures(
+                        onPress = {
+                            backgroundColor = LightColor.N10
+                            this.awaitRelease()
+                            backgroundColor = Color.Transparent
+                        },
+                    )
+                }
         ) {
-            icon()
-            Spacer(modifier = Modifier.width(12.dp))
-            Text(
-                text = text,
-                style = typography.body1,
-                color = colors.ERROR,
-                fontWeight = FontWeight.Normal
-            )
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clip(RoundedCornerShape(10.dp))
+                    .background(backgroundColor),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                icon()
+                Text(
+                    text = text,
+                    style = typography.body1,
+                    color = colors.ERROR,
+                    fontWeight = FontWeight.Normal
+                )
+            }
         }
     }
 }

--- a/presentation/src/main/java/com/sms/presentation/main/ui/main/component/ModalBottomSheetItem.kt
+++ b/presentation/src/main/java/com/sms/presentation/main/ui/main/component/ModalBottomSheetItem.kt
@@ -1,0 +1,32 @@
+package com.sms.presentation.main.ui.main.component
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.msg.sms.design.modifier.smsClickable
+import com.msg.sms.design.theme.SMSTheme
+
+@Composable
+fun ModalBottomSheetItem(text: String, icon: @Composable () -> Unit, onClick: () -> Unit) {
+    SMSTheme { colors, typography ->
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .smsClickable(onClick = onClick),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            icon()
+            Spacer(modifier = Modifier.width(12.dp))
+            Text(
+                text = text,
+                style = typography.body1,
+                color = colors.ERROR,
+                fontWeight = FontWeight.Normal
+            )
+        }
+    }
+}

--- a/presentation/src/main/java/com/sms/presentation/main/ui/main/component/ModalBottomSheetItem.kt
+++ b/presentation/src/main/java/com/sms/presentation/main/ui/main/component/ModalBottomSheetItem.kt
@@ -13,7 +13,6 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import com.msg.sms.design.modifier.smsClickable
 import com.msg.sms.design.theme.SMSTheme
 import com.msg.sms.design.theme.color.LightColor
 
@@ -32,13 +31,13 @@ fun ModalBottomSheetItem(
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(horizontal = 16.dp)
-                .smsClickable(rippleEnabled = false, onClick = onClick)
                 .pointerInput(Unit) {
                     detectTapGestures(
                         onPress = {
                             backgroundColor = LightColor.N10
                             this.awaitRelease()
                             backgroundColor = Color.Transparent
+                            onClick()
                         },
                     )
                 }

--- a/presentation/src/main/java/com/sms/presentation/main/ui/main/screen/MainScreen.kt
+++ b/presentation/src/main/java/com/sms/presentation/main/ui/main/screen/MainScreen.kt
@@ -5,10 +5,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.ExperimentalMaterialApi
-import androidx.compose.material.ModalBottomSheetLayout
-import androidx.compose.material.ModalBottomSheetValue
-import androidx.compose.material.rememberModalBottomSheetState
+import androidx.compose.material.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -16,8 +13,12 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
 import com.msg.sms.design.component.button.ListFloatingButton
+import com.msg.sms.design.icon.RedLogoutIcon
+import com.msg.sms.design.icon.RedWithdrawalIcon
+import com.msg.sms.design.theme.SMSTheme
 import com.msg.sms.domain.model.student.response.StudentModel
 import com.sms.presentation.main.ui.main.component.MainScreenTopBar
+import com.sms.presentation.main.ui.main.component.ModalBottomSheetItem
 import com.sms.presentation.main.ui.main.component.StudentListComponent
 import com.sms.presentation.main.viewmodel.StudentListViewModel
 import com.sms.presentation.main.viewmodel.util.Event
@@ -27,8 +28,7 @@ import kotlinx.coroutines.launch
 @OptIn(ExperimentalMaterialApi::class)
 @Composable
 fun MainScreen(
-    navController: NavController,
-    viewModel: StudentListViewModel
+    navController: NavController, viewModel: StudentListViewModel
 ) {
     val listState = rememberLazyListState()
     val scope = rememberCoroutineScope()
@@ -48,27 +48,51 @@ fun MainScreen(
         rememberModalBottomSheetState(initialValue = ModalBottomSheetValue.Hidden)
 
     LaunchedEffect("GetStudentList") {
-        getStudentList(
-            viewModel = viewModel,
+        getStudentList(viewModel = viewModel,
             progressState = { progressState.value = it },
             onSuccess = { list, size ->
                 studentList.value += list
                 listTotalSize.value = size
-            }
-        )
+            })
     }
 
     LaunchedEffect("isScrolled") {
-        snapshotFlow { listState.layoutInfo.visibleItemsInfo.first().index != 0 }
-            .collect {
-                if (isScrolled.value != it)
-                    isScrolled.value = it
-            }
+        snapshotFlow { listState.layoutInfo.visibleItemsInfo.first().index != 0 }.collect {
+            if (isScrolled.value != it) isScrolled.value = it
+        }
     }
 
     ModalBottomSheetLayout(
         sheetContent = {
-
+            SMSTheme { colors, typography ->
+                Spacer(modifier = Modifier.height(24.dp))
+                ModalBottomSheetItem(
+                    text = "로그아웃",
+                    icon = {
+                        RedLogoutIcon(
+                            modifier = Modifier.padding(
+                                start = 20.dp, bottom = 12.dp, top = 12.dp
+                            )
+                        )
+                    }
+                ) {
+                    /*TODO(Kimhyunseung) - 로그아웃 */
+                }
+                Spacer(modifier = Modifier.height(8.dp))
+                ModalBottomSheetItem(
+                    text = "회원탈퇴",
+                    icon = {
+                        RedWithdrawalIcon(
+                            modifier = Modifier.padding(
+                                start = 20.dp, bottom = 12.dp, top = 12.dp
+                            )
+                        )
+                    }
+                ) {
+                    /*TODO(Kimhyunseung) - 회원탈퇴 */
+                }
+                Spacer(modifier = Modifier.height(16.dp))
+            }
         },
         sheetState = bottomSheetState,
         sheetShape = RoundedCornerShape(topStart = 16.dp, topEnd = 16.dp)
@@ -78,16 +102,14 @@ fun MainScreen(
                 .fillMaxSize()
                 .background(Color.White)
         ) {
-            MainScreenTopBar(
-                profileImageUrl = "",
+            MainScreenTopBar(profileImageUrl = "",
                 isScolled = isScrolled.value,
                 filterButtonOnClick = { /*TODO (KimHyunseung) : 필터 Screen으로 이동*/ },
                 profileButtonOnClick = {
                     scope.launch {
                         bottomSheetState.show()
                     }
-                }
-            )
+                })
             Box(modifier = Modifier.fillMaxSize()) {
                 StudentListComponent(
                     listState = listState,
@@ -115,13 +137,11 @@ fun MainScreen(
     LaunchedEffect("Pagination") {
         val response = viewModel.getStudentListResponse.value
 
-        snapshotFlow { listState.layoutInfo.visibleItemsInfo.lastOrNull()?.index }
-            .filter { it == listState.layoutInfo.totalItemsCount - 1 }
+        snapshotFlow { listState.layoutInfo.visibleItemsInfo.lastOrNull()?.index }.filter { it == listState.layoutInfo.totalItemsCount - 1 }
             .collect {
                 val isSuccess = response is Event.Success
                 if (isSuccess && it != 0) {
-                    val isIncompleteData =
-                        studentList.value.size < response.data!!.totalSize
+                    val isIncompleteData = studentList.value.size < response.data!!.totalSize
                     if (isIncompleteData) {
                         viewModel.getStudentListRequest(response.data.page + 1, 20)
                     }

--- a/presentation/src/main/java/com/sms/presentation/main/ui/main/screen/MainScreen.kt
+++ b/presentation/src/main/java/com/sms/presentation/main/ui/main/screen/MainScreen.kt
@@ -69,9 +69,7 @@ fun MainScreen(
                 text = "로그아웃",
                 icon = {
                     RedLogoutIcon(
-                        modifier = Modifier.padding(
-                            start = 20.dp, bottom = 12.dp, top = 12.dp
-                        )
+                        modifier = Modifier.padding(12.dp)
                     )
                 }
             ) {
@@ -82,9 +80,7 @@ fun MainScreen(
                 text = "회원탈퇴",
                 icon = {
                     RedWithdrawalIcon(
-                        modifier = Modifier.padding(
-                            start = 20.dp, bottom = 12.dp, top = 12.dp
-                        )
+                        modifier = Modifier.padding(12.dp)
                     )
                 }
             ) {
@@ -100,14 +96,16 @@ fun MainScreen(
                 .fillMaxSize()
                 .background(Color.White)
         ) {
-            MainScreenTopBar(profileImageUrl = "",
+            MainScreenTopBar(
+                profileImageUrl = "",
                 isScolled = isScrolled.value,
                 filterButtonOnClick = { /*TODO (KimHyunseung) : 필터 Screen으로 이동*/ },
                 profileButtonOnClick = {
                     scope.launch {
                         bottomSheetState.show()
                     }
-                })
+                }
+            )
             Box(modifier = Modifier.fillMaxSize()) {
                 StudentListComponent(
                     listState = listState,

--- a/presentation/src/main/java/com/sms/presentation/main/ui/main/screen/MainScreen.kt
+++ b/presentation/src/main/java/com/sms/presentation/main/ui/main/screen/MainScreen.kt
@@ -4,6 +4,11 @@ import android.util.Log
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.ExperimentalMaterialApi
+import androidx.compose.material.ModalBottomSheetLayout
+import androidx.compose.material.ModalBottomSheetValue
+import androidx.compose.material.rememberModalBottomSheetState
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -19,6 +24,7 @@ import com.sms.presentation.main.viewmodel.util.Event
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.launch
 
+@OptIn(ExperimentalMaterialApi::class)
 @Composable
 fun MainScreen(
     navController: NavController,
@@ -38,6 +44,8 @@ fun MainScreen(
     val isScrolled = remember {
         mutableStateOf(false)
     }
+    val bottomSheetState =
+        rememberModalBottomSheetState(initialValue = ModalBottomSheetValue.Hidden)
 
     LaunchedEffect("GetStudentList") {
         getStudentList(
@@ -58,36 +66,48 @@ fun MainScreen(
             }
     }
 
-    Column(
-        modifier = Modifier
-            .fillMaxSize()
-            .background(Color.White)
+    ModalBottomSheetLayout(
+        sheetContent = {
+
+        },
+        sheetState = bottomSheetState,
+        sheetShape = RoundedCornerShape(topStart = 16.dp, topEnd = 16.dp)
     ) {
-        MainScreenTopBar(
-            profileImageUrl = "",
-            isScolled = isScrolled.value,
-            filterButtonOnClick = { /*TODO (KimHyunseung) : 필터 Screen으로 이동*/ },
-            profileButtonOnClick = { /*TODO (KimHyunseung) : 마이페이지로 이동*/ }
-        )
-        Box(modifier = Modifier.fillMaxSize()) {
-            StudentListComponent(
-                listState = listState,
-                progressState = progressState.value,
-                studentList = studentList.value,
-                listTotalSize = listTotalSize.value
-            ) {
-                //TODO (Kimhyunseung) : 디테일 페이지로 이동
-            }
-            Box(
-                modifier = Modifier
-                    .align(Alignment.BottomEnd)
-                    .padding(bottom = 32.dp, end = 20.dp)
-            ) {
-                ListFloatingButton(onClick = {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(Color.White)
+        ) {
+            MainScreenTopBar(
+                profileImageUrl = "",
+                isScolled = isScrolled.value,
+                filterButtonOnClick = { /*TODO (KimHyunseung) : 필터 Screen으로 이동*/ },
+                profileButtonOnClick = {
                     scope.launch {
-                        listState.animateScrollToItem(0)
+                        bottomSheetState.show()
                     }
-                })
+                }
+            )
+            Box(modifier = Modifier.fillMaxSize()) {
+                StudentListComponent(
+                    listState = listState,
+                    progressState = progressState.value,
+                    studentList = studentList.value,
+                    listTotalSize = listTotalSize.value
+                ) {
+                    //TODO (Kimhyunseung) : 디테일 페이지로 이동
+                }
+                Box(
+                    modifier = Modifier
+                        .align(Alignment.BottomEnd)
+                        .padding(bottom = 32.dp, end = 20.dp)
+                ) {
+                    ListFloatingButton(onClick = {
+                        scope.launch {
+                            listState.animateScrollToItem(0)
+                        }
+                    })
+                }
             }
         }
     }

--- a/presentation/src/main/java/com/sms/presentation/main/ui/main/screen/MainScreen.kt
+++ b/presentation/src/main/java/com/sms/presentation/main/ui/main/screen/MainScreen.kt
@@ -15,7 +15,6 @@ import androidx.navigation.NavController
 import com.msg.sms.design.component.button.ListFloatingButton
 import com.msg.sms.design.icon.RedLogoutIcon
 import com.msg.sms.design.icon.RedWithdrawalIcon
-import com.msg.sms.design.theme.SMSTheme
 import com.msg.sms.domain.model.student.response.StudentModel
 import com.sms.presentation.main.ui.main.component.MainScreenTopBar
 import com.sms.presentation.main.ui.main.component.ModalBottomSheetItem
@@ -28,7 +27,8 @@ import kotlinx.coroutines.launch
 @OptIn(ExperimentalMaterialApi::class)
 @Composable
 fun MainScreen(
-    navController: NavController, viewModel: StudentListViewModel
+    navController: NavController,
+    viewModel: StudentListViewModel
 ) {
     val listState = rememberLazyListState()
     val scope = rememberCoroutineScope()
@@ -64,35 +64,33 @@ fun MainScreen(
 
     ModalBottomSheetLayout(
         sheetContent = {
-            SMSTheme { colors, typography ->
-                Spacer(modifier = Modifier.height(24.dp))
-                ModalBottomSheetItem(
-                    text = "로그아웃",
-                    icon = {
-                        RedLogoutIcon(
-                            modifier = Modifier.padding(
-                                start = 20.dp, bottom = 12.dp, top = 12.dp
-                            )
+            Spacer(modifier = Modifier.height(24.dp))
+            ModalBottomSheetItem(
+                text = "로그아웃",
+                icon = {
+                    RedLogoutIcon(
+                        modifier = Modifier.padding(
+                            start = 20.dp, bottom = 12.dp, top = 12.dp
                         )
-                    }
-                ) {
-                    /*TODO(Kimhyunseung) - 로그아웃 */
+                    )
                 }
-                Spacer(modifier = Modifier.height(8.dp))
-                ModalBottomSheetItem(
-                    text = "회원탈퇴",
-                    icon = {
-                        RedWithdrawalIcon(
-                            modifier = Modifier.padding(
-                                start = 20.dp, bottom = 12.dp, top = 12.dp
-                            )
-                        )
-                    }
-                ) {
-                    /*TODO(Kimhyunseung) - 회원탈퇴 */
-                }
-                Spacer(modifier = Modifier.height(16.dp))
+            ) {
+                /*TODO(Kimhyunseung) - 로그아웃 */
             }
+            Spacer(modifier = Modifier.height(8.dp))
+            ModalBottomSheetItem(
+                text = "회원탈퇴",
+                icon = {
+                    RedWithdrawalIcon(
+                        modifier = Modifier.padding(
+                            start = 20.dp, bottom = 12.dp, top = 12.dp
+                        )
+                    )
+                }
+            ) {
+                /*TODO(Kimhyunseung) - 회원탈퇴 */
+            }
+            Spacer(modifier = Modifier.height(16.dp))
         },
         sheetState = bottomSheetState,
         sheetShape = RoundedCornerShape(topStart = 16.dp, topEnd = 16.dp)


### PR DESCRIPTION
## 💡 개요
- 로그아웃, 회원탈퇴를 위한 바텀시트 UI제작
## 📃 작업내용
https://github.com/GSM-MSG/SMS-Android/assets/80810303/485687f3-927d-41be-9267-760c4a4e9492

10303/f01b68f9-8b71-4960-92a9-71c070828e28">

- modal 바텀시트를 활용하여 제작
- 중복되는 코드 컴포넌트로 분리

## 🎸 기타
- 다른 다이얼로그 들과도 겹치는 코드가 있어서 추후에 디자인 시스템에 공용 다이얼로그 아이템 추가 필요