### PR TITLE
🔀 :: (#168) - 게스트 상태일때 디테일 페이지 이슈 해결

### DIFF
--- a/presentation/src/main/java/com/sms/presentation/main/ui/detail/StudentDetailScreen.kt
+++ b/presentation/src/main/java/com/sms/presentation/main/ui/detail/StudentDetailScreen.kt
@@ -76,7 +76,7 @@ fun StudentDetailScreen(
         StudentDetailComponent(
             imageHeight = imageHeight.value,
             techStack = studentDetailData.techStacks,
-            name = studentDetailData.name,
+            name = studentDetailData.name.replace("**","소금"),
             major = studentDetailData.major,
             modifier = Modifier.align(Alignment.TopCenter),
             isNotGuest = role == "ROLE_TEACHER" || role == "ROLE_STUDENT",


### PR DESCRIPTION
## 💡 개요
- 게스트 상태일때 디테일 페이지의 이름이 소금으로 치환되지 않는 이슈를 해결합니다.

## 📃 작업내용
- 게스트상태일때 정보를 넘겨줄때 
```kotlin
replace("**","소금")
```
하도록 처리
