### PR TITLE
🔀 :: (#198) - close softkeyboard when showing bottom sheet

### DIFF
--- a/presentation/src/main/java/com/sms/presentation/main/ui/fill_out_information/component/ProfileComponent.kt
+++ b/presentation/src/main/java/com/sms/presentation/main/ui/fill_out_information/component/ProfileComponent.kt
@@ -16,6 +16,7 @@ import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import coil.compose.rememberAsyncImagePainter
@@ -26,7 +27,9 @@ import com.msg.sms.design.component.textfield.SmsTextField
 import com.msg.sms.design.icon.OpenButtonIcon
 import com.msg.sms.design.icon.ProfileIcon
 import com.msg.sms.design.theme.SMSTheme
+import com.sms.presentation.main.ui.fill_out_information.FillOutInformationActivity
 import com.sms.presentation.main.ui.fill_out_information.data.ProfileData
+import com.sms.presentation.main.ui.util.hideKeyboard
 import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalMaterialApi::class)
@@ -48,6 +51,8 @@ fun ProfileComponent(
 ) {
     SMSTheme { _, typography ->
         val coroutineScope = rememberCoroutineScope()
+
+        val context = LocalContext.current as FillOutInformationActivity
 
         val introduce = remember {
             mutableStateOf(if (data.introduce != "") data.introduce else "")
@@ -92,6 +97,7 @@ fun ProfileComponent(
                 ProfileIcon(modifier = Modifier.clickable {
                     isProfilePictureBottomSheet(true)
                     coroutineScope.launch {
+                        context.hideKeyboard()
                         bottomSheetScaffoldState.show()
                     }
                 })
@@ -107,6 +113,7 @@ fun ProfileComponent(
                         .clickable {
                             isProfilePictureBottomSheet(true)
                             coroutineScope.launch {
+                                context.hideKeyboard()
                                 bottomSheetScaffoldState.show()
                             }
                         }
@@ -146,6 +153,7 @@ fun ProfileComponent(
                     isProfilePictureBottomSheet(false)
                     if (isEnable) {
                         coroutineScope.launch {
+                            context.hideKeyboard()
                             bottomSheetScaffoldState.show()
                         }
                     }

--- a/presentation/src/main/java/com/sms/presentation/main/ui/fill_out_information/component/WorkConditionComponent.kt
+++ b/presentation/src/main/java/com/sms/presentation/main/ui/fill_out_information/component/WorkConditionComponent.kt
@@ -9,6 +9,7 @@ import androidx.compose.material.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
@@ -22,7 +23,9 @@ import com.msg.sms.design.component.textfield.SmsTextField
 import com.msg.sms.design.icon.OpenButtonIcon
 import com.msg.sms.design.icon.TrashCanIcon
 import com.msg.sms.design.theme.SMSTheme
+import com.sms.presentation.main.ui.fill_out_information.FillOutInformationActivity
 import com.sms.presentation.main.ui.fill_out_information.data.WorkConditionData
+import com.sms.presentation.main.ui.util.hideKeyboard
 import com.sms.presentation.main.viewmodel.FillOutViewModel
 import kotlinx.coroutines.launch
 
@@ -43,6 +46,8 @@ fun WorkConditionComponent(
         val wantPayroll = remember {
             mutableStateOf(if (data.salary != "") data.salary else "")
         }
+
+        val context = LocalContext.current as FillOutInformationActivity
 
         val coroutineScope = rememberCoroutineScope()
 
@@ -85,6 +90,7 @@ fun WorkConditionComponent(
                         readOnly = true,
                         clickAction = {
                             coroutineScope.launch {
+                                context.hideKeyboard()
                                 bottomSheetState.show()
                             }
                         },

--- a/presentation/src/main/java/com/sms/presentation/main/ui/util/hideKeyboard.kt
+++ b/presentation/src/main/java/com/sms/presentation/main/ui/util/hideKeyboard.kt
@@ -1,0 +1,12 @@
+package com.sms.presentation.main.ui.util
+
+import android.app.Activity
+import android.content.Context
+import android.view.inputmethod.InputMethodManager
+
+fun Activity.hideKeyboard() {
+    if(this.currentFocus != null) {
+        val inputManager = this.getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
+        inputManager.hideSoftInputFromWindow(this.currentFocus!!.windowToken, InputMethodManager.HIDE_NOT_ALWAYS)
+    }
+}


### PR DESCRIPTION
키보드가 떠있는 상태에서 바텀 시트를 띄우면 바텀 시트가 보이지 않는 문제를 키보드를 hide시켜 해결하였습니다.