### PR TITLE
🔀 :: (#221) - GAuth 업데이트 적용

### DIFF
--- a/buildSrc/src/main/java/Versions.kt
+++ b/buildSrc/src/main/java/Versions.kt
@@ -24,7 +24,7 @@ object Versions {
 
     const val RETROFIT = "2.9.0"
     const val OKHTTP = "4.10.0"
-    const val GAUTH = "1.1.0"
+    const val GAUTH = "1.1.2"
 
     const val PREFERENCES = "1.0.0"
 

--- a/presentation/src/main/java/com/sms/presentation/main/ui/login/LoginActivity.kt
+++ b/presentation/src/main/java/com/sms/presentation/main/ui/login/LoginActivity.kt
@@ -6,8 +6,6 @@ import androidx.activity.compose.setContent
 import androidx.activity.viewModels
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.lifecycle.lifecycleScope
-import com.msg.gauthsignin.GAuthSigninWebView
-import com.sms.presentation.BuildConfig
 import com.sms.presentation.main.ui.base.BaseActivity
 import com.sms.presentation.main.ui.fill_out_information.FillOutInformationActivity
 import com.sms.presentation.main.ui.login.component.LoginScreen
@@ -35,15 +33,8 @@ class LoginActivity : BaseActivity() {
         setContent {
             LoginScreen(
                 context = this@LoginActivity,
-                onLoginButtonClick = {
-                    setContent {
-                        GAuthSigninWebView(
-                            clientId = BuildConfig.CLIENT_ID,
-                            redirectUri = BuildConfig.REDIRECT_URI
-                        ) { code ->
-                            viewModel.gAuthLogin(code = code)
-                        }
-                    }
+                loginCallBack = { code ->
+                    viewModel.gAuthLogin(code)
                 },
                 onLookAroundToGuestButtonClick = {
                     pageController(true)

--- a/presentation/src/main/java/com/sms/presentation/main/ui/login/component/LoginScreen.kt
+++ b/presentation/src/main/java/com/sms/presentation/main/ui/login/component/LoginScreen.kt
@@ -1,18 +1,29 @@
 package com.sms.presentation.main.ui.login.component
 
 import android.content.Context
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.layout.*
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import com.msg.gauthsignin.GAuthSigninWebView
+import com.sms.presentation.BuildConfig
 
 @Composable
 fun LoginScreen(
     context: Context,
-    onLoginButtonClick: () -> Unit,
+    loginCallBack: (code: String) -> Unit,
     onLookAroundToGuestButtonClick: () -> Unit,
 ) {
+    val webViewVisible = remember {
+        mutableStateOf(false)
+    }
+
     Box {
         LoginPageBackGround()
         TopComponent(context)
@@ -22,7 +33,7 @@ fun LoginScreen(
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
             LoginButton {
-                onLoginButtonClick()
+                webViewVisible.value = true
             }
             Spacer(modifier = Modifier.height(16.dp))
             Row {
@@ -33,6 +44,23 @@ fun LoginScreen(
                 ShowTheTermsOfUse(context = context)
             }
             Spacer(modifier = Modifier.height(73.dp))
+        }
+        AnimatedVisibility(
+            visible = webViewVisible.value,
+            modifier = Modifier.fillMaxSize(),
+            enter = slideInVertically {
+                -it
+            },
+            exit = slideOutVertically {
+                -it
+            }
+        ) {
+            GAuthSigninWebView(
+                clientId = BuildConfig.CLIENT_ID,
+                redirectUri = BuildConfig.REDIRECT_URI,
+                onBackPressed = { webViewVisible.value = false },
+                callBack = loginCallBack
+            )
         }
     }
 }


### PR DESCRIPTION
## 💡 개요
- GAuth v1.1.2 적용

## 📃 작업내용
- GAuth Version Up을 진행했습니다.
- 뒤로가기 클릭시에 다시 인트로 페이지로 나와지도록 코드 추가
- 자연스러운 뷰 전환을 위해 애니메이션 추가

https://github.com/GSM-MSG/SMS-Android/assets/80810303/d7974276-d512-433f-9aa8-110e480d7d2a



## 🔀 변경사항
- GAuthWebView에 대한 컴포넌트가 LoginScreen에 포함되도록 수정하였습니다.