### PR TITLE
🔀 :: (#224) - SmsCustomTextFiled Leading Icon 이슈 해결

### DIFF
--- a/design-system/src/main/java/com/msg/sms/design/component/textfield/SmsTextField.kt
+++ b/design-system/src/main/java/com/msg/sms/design/component/textfield/SmsTextField.kt
@@ -131,13 +131,7 @@ fun SmsCustomTextField(
                     unfocusedBorderColor = Color.Transparent,
                     cursorColor = colors.P2
                 ),
-                leadingIcon = {
-                    if (leadingIcon != null) {
-                        IconButton(onClick = clickAction) {
-                            leadingIcon()
-                        }
-                    }
-                },
+                leadingIcon = leadingIcon,
                 trailingIcon = {
                     if (endIcon != null) {
                         IconButton(onClick = clickAction) {


### PR DESCRIPTION
## 💡 개요
- SmsCustomTextFiled Leading Icon 이슈 해결
## 🔀 변경사항
- icon이 전달 되지 않은 경우에 OutlinedTextField의 Leading Icon에 null이 전달되도록 코드 수정
