### PR TITLE
🔀 :: (#220) - modify detail page UI according to changed feature

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="CompilerConfiguration">
-    <bytecodeTargetLevel target="11" />
+    <bytecodeTargetLevel target="17" />
   </component>
 </project>

--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="KotlinJpsPluginSettings">
+    <option name="version" value="1.7.0" />
+  </component>
+</project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,7 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" default="true" project-jdk-name="11" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="jbr-17" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/data/src/main/java/com/msg/sms/data/remote/dto/student/response/GetStudentForAnonymousResponse.kt
+++ b/data/src/main/java/com/msg/sms/data/remote/dto/student/response/GetStudentForAnonymousResponse.kt
@@ -8,6 +8,8 @@ data class GetStudentForAnonymousResponse(
     val major: String,
     val profileImg: String,
     val techStack: List<String>,
+    val projectList: List<String>,
+    val awardData: List<String>
 )
 
 fun GetStudentForAnonymousResponse.toGetStudentForAnonymous(): GetStudentForAnonymous {
@@ -16,6 +18,8 @@ fun GetStudentForAnonymousResponse.toGetStudentForAnonymous(): GetStudentForAnon
         introduce = introduce,
         major = major,
         profileImg = profileImg,
-        techStack = techStack
+        techStack = techStack,
+        projectList = projectList,
+        awardData = awardData
     )
 }

--- a/design-system/src/main/java/com/msg/sms/design/component/item/TechStackItem.kt
+++ b/design-system/src/main/java/com/msg/sms/design/component/item/TechStackItem.kt
@@ -3,6 +3,7 @@ package com.msg.sms.design.component.item
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
@@ -10,6 +11,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.msg.sms.design.theme.SMSTheme
 
@@ -18,6 +20,7 @@ fun TechStackItem(techStack: String) {
     SMSTheme { colors, typography ->
         Box(
             modifier = Modifier
+                .wrapContentSize()
                 .clip(RoundedCornerShape(8.dp))
                 .background(colors.N10)
         ) {
@@ -32,4 +35,15 @@ fun TechStackItem(techStack: String) {
             )
         }
     }
+}
+
+@Preview
+@Composable
+private fun TechStackItemPre() {
+    TechStackItem(techStack = "aa")
+}
+@Preview
+@Composable
+private fun TechStackItemLongTextPre() {
+    TechStackItem(techStack = "Android Studio")
 }

--- a/design-system/src/main/java/com/msg/sms/design/component/text/TechStackRow.kt
+++ b/design-system/src/main/java/com/msg/sms/design/component/text/TechStackRow.kt
@@ -3,7 +3,6 @@ package com.msg.sms.design.component.text
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.lazy.staggeredgrid.LazyHorizontalStaggeredGrid
 import androidx.compose.foundation.lazy.staggeredgrid.StaggeredGridCells
@@ -21,10 +20,10 @@ fun TechStackRow(modifier: Modifier, techStack: List<String>) {
     LazyHorizontalStaggeredGrid(
         modifier = modifier
             .fillMaxWidth()
-            .heightIn(max = if (techStack.size <= 5) 30.dp else if (techStack.size in 5..12) 64.dp else 98.dp),
+            .heightIn(max = if (techStack.size <= 5) 30.dp else if (techStack.size in 5..10) 64.dp else if (techStack.size in 11..15) 98.dp else 132.dp),
         verticalArrangement = Arrangement.spacedBy(4.dp),
         horizontalItemSpacing = 4.dp,
-        rows = StaggeredGridCells.Fixed(if (techStack.size <= 5) 1 else if (techStack.size in 5..12) 2 else 3)
+        rows = StaggeredGridCells.Fixed(if (techStack.size <= 5) 1 else if (techStack.size in 5..10) 2 else if (techStack.size in 11..15) 3 else 4)
     ) {
         itemsIndexed(techStack) { _: Int, item: String ->
             TechStackItem(techStack = item)

--- a/design-system/src/main/java/com/msg/sms/design/component/text/TechStackRow.kt
+++ b/design-system/src/main/java/com/msg/sms/design/component/text/TechStackRow.kt
@@ -1,0 +1,51 @@
+package com.msg.sms.design.component.text
+
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.lazy.staggeredgrid.LazyHorizontalStaggeredGrid
+import androidx.compose.foundation.lazy.staggeredgrid.StaggeredGridCells
+import androidx.compose.foundation.lazy.staggeredgrid.itemsIndexed
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.msg.sms.design.component.item.TechStackItem
+import com.msg.sms.design.util.AddBody1TitleText
+
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+fun TechStackRow(modifier: Modifier, techStack: List<String>) {
+    LazyHorizontalStaggeredGrid(
+        modifier = modifier
+            .fillMaxWidth()
+            .heightIn(max = if (techStack.size <= 5) 30.dp else if (techStack.size in 5..12) 64.dp else 98.dp),
+        verticalArrangement = Arrangement.spacedBy(4.dp),
+        horizontalItemSpacing = 4.dp,
+        rows = StaggeredGridCells.Fixed(if (techStack.size <= 5) 1 else if (techStack.size in 5..12) 2 else 3)
+    ) {
+        itemsIndexed(techStack) { _: Int, item: String ->
+            TechStackItem(techStack = item)
+        }
+    }
+}
+
+@Preview
+@Composable
+fun TechStackRowPre() {
+    AddBody1TitleText(titleText = "asddf", spaceSize = 8) {
+        TechStackRow(
+            modifier = Modifier,
+            techStack = listOf(
+                "Kotlin",
+                "MVVM",
+                "Compose UI",
+                "Jetpack Compose",
+                "Hilt",
+                "Android Studio"
+            )
+        )
+    }
+}

--- a/design-system/src/main/java/com/msg/sms/design/component/text/TechStackTextComponent.kt
+++ b/design-system/src/main/java/com/msg/sms/design/component/text/TechStackTextComponent.kt
@@ -14,7 +14,7 @@ import androidx.compose.ui.unit.dp
 import com.msg.sms.design.theme.SMSTheme
 
 @Composable
-fun TechStackTextComponent(str: String, modifier: Modifier = Modifier) {
+fun TechStackTextComponent(text: String, modifier: Modifier = Modifier) {
     SMSTheme { colors, typography ->
         Box(
             modifier = modifier
@@ -22,7 +22,7 @@ fun TechStackTextComponent(str: String, modifier: Modifier = Modifier) {
                 .clip(RoundedCornerShape(8.dp))
         ) {
             Text(
-                text = str,
+                text = text,
                 modifier = Modifier
                     .padding(vertical = 6.5.dp, horizontal = 12.dp), style = typography.caption2,
                 color = colors.N40,
@@ -35,5 +35,5 @@ fun TechStackTextComponent(str: String, modifier: Modifier = Modifier) {
 @Preview
 @Composable
 fun TechStackTextComponentPre() {
-    TechStackTextComponent(str = "테스트")
+    TechStackTextComponent(text = "테스트")
 }

--- a/design-system/src/main/java/com/msg/sms/design/component/text/TechStackTextComponent.kt
+++ b/design-system/src/main/java/com/msg/sms/design/component/text/TechStackTextComponent.kt
@@ -1,0 +1,39 @@
+package com.msg.sms.design.component.text
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.msg.sms.design.theme.SMSTheme
+
+@Composable
+fun TechStackTextComponent(str: String, modifier: Modifier = Modifier) {
+    SMSTheme { colors, typography ->
+        Box(
+            modifier = modifier
+                .background(colors.N10)
+                .clip(RoundedCornerShape(8.dp))
+        ) {
+            Text(
+                text = str,
+                modifier = Modifier
+                    .padding(vertical = 6.5.dp, horizontal = 12.dp), style = typography.caption2,
+                color = colors.N40,
+                fontWeight = FontWeight.Normal
+            )
+        }
+    }
+}
+
+@Preview
+@Composable
+fun TechStackTextComponentPre() {
+    TechStackTextComponent(str = "테스트")
+}

--- a/design-system/src/main/java/com/msg/sms/design/icon/SmsIcon.kt
+++ b/design-system/src/main/java/com/msg/sms/design/icon/SmsIcon.kt
@@ -255,6 +255,6 @@ fun TopEndArrowIcon(
     Image(
         painter = painterResource(id = R.drawable.ic_top_end_arrow),
         contentDescription = "화살표 아이콘",
-                modifier = modifier
+        modifier = modifier
     )
 }

--- a/design-system/src/main/java/com/msg/sms/design/icon/SmsIcon.kt
+++ b/design-system/src/main/java/com/msg/sms/design/icon/SmsIcon.kt
@@ -8,7 +8,7 @@ import com.sms.design_system.R
 
 @Composable
 fun BackButtonIcon(
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
 ) {
     Image(
         painter = painterResource(id = R.drawable.ic_back_btn),
@@ -19,7 +19,7 @@ fun BackButtonIcon(
 
 @Composable
 fun CameraIcon(
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
 ) {
     Image(
         painter = painterResource(id = R.drawable.ic_camera),
@@ -30,7 +30,7 @@ fun CameraIcon(
 
 @Composable
 fun CheckButtonIcon(
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
 ) {
     Image(
         painter = painterResource(id = R.drawable.ic_check_btn),
@@ -41,7 +41,7 @@ fun CheckButtonIcon(
 
 @Composable
 fun DeleteButtonIcon(
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
 ) {
     Image(
         painter = painterResource(id = R.drawable.ic_delete_btn),
@@ -52,7 +52,7 @@ fun DeleteButtonIcon(
 
 @Composable
 fun FilledPlusButtonIcon(
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
 ) {
     Image(
         painter = painterResource(id = R.drawable.ic_filled_plus_btn),
@@ -63,7 +63,7 @@ fun FilledPlusButtonIcon(
 
 @Composable
 fun OpenButtonIcon(
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
 ) {
     Image(
         painter = painterResource(id = R.drawable.ic_open_btn),
@@ -74,7 +74,7 @@ fun OpenButtonIcon(
 
 @Composable
 fun PlusButtonIcon(
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
 ) {
     Image(
         painter = painterResource(id = R.drawable.ic_plus_btn),
@@ -85,7 +85,7 @@ fun PlusButtonIcon(
 
 @Composable
 fun PlusButtonGrayIcon(
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
 ) {
     Image(
         painter = painterResource(id = R.drawable.ic_plus_btn_gray),
@@ -96,7 +96,7 @@ fun PlusButtonGrayIcon(
 
 @Composable
 fun FilterButtonIcon(
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
 ) {
     Image(
         painter = painterResource(id = R.drawable.ic_filter_btn),
@@ -107,7 +107,7 @@ fun FilterButtonIcon(
 
 @Composable
 fun ProfileIcon(
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
 ) {
     Image(
         painter = painterResource(id = R.drawable.ic_profile_btn),
@@ -118,7 +118,7 @@ fun ProfileIcon(
 
 @Composable
 fun TrashCanIcon(
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
 ) {
     Image(
         painter = painterResource(id = R.drawable.ic_trash_can),
@@ -129,7 +129,7 @@ fun TrashCanIcon(
 
 @Composable
 fun GalleryIcon(
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
 ) {
     Image(
         painter = painterResource(id = R.drawable.ic_gallery),
@@ -140,7 +140,7 @@ fun GalleryIcon(
 
 @Composable
 fun SmsLogoIcon(
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
 ) {
     Image(
         painter = painterResource(id = R.drawable.ic_sms_logo),
@@ -151,7 +151,7 @@ fun SmsLogoIcon(
 
 @Composable
 fun ProfileDefaultIcon(
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
 ) {
     Image(
         painter = painterResource(id = R.drawable.ic_profile_default),
@@ -162,7 +162,7 @@ fun ProfileDefaultIcon(
 
 @Composable
 fun CheckedIcon(
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
 ) {
     Image(
         painter = painterResource(id = R.drawable.ic_checked_btn),
@@ -173,7 +173,7 @@ fun CheckedIcon(
 
 @Composable
 fun UnCheckedIcon(
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
 ) {
     Image(
         painter = painterResource(id = R.drawable.ic_unchecked_btn),
@@ -184,7 +184,7 @@ fun UnCheckedIcon(
 
 @Composable
 fun SearchIcon(
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
 ) {
     Image(
         painter = painterResource(id = R.drawable.ic_search),
@@ -195,7 +195,7 @@ fun SearchIcon(
 
 @Composable
 fun BookIcon(
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
 ) {
     Image(
         painter = painterResource(id = R.drawable.ic_book),
@@ -206,7 +206,7 @@ fun BookIcon(
 
 @Composable
 fun ArrowUpWardIcon(
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
 ) {
     Image(
         painter = painterResource(id = R.drawable.ic_arrow_upward),
@@ -217,7 +217,7 @@ fun ArrowUpWardIcon(
 
 @Composable
 fun RedLogoutIcon(
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
 ) {
     Image(
         painter = painterResource(id = R.drawable.ic_red_logout),
@@ -228,7 +228,7 @@ fun RedLogoutIcon(
 
 @Composable
 fun RedWithdrawalIcon(
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
 ) {
     Image(
         painter = painterResource(id = R.drawable.ic_red_withdrawal),
@@ -239,11 +239,22 @@ fun RedWithdrawalIcon(
 
 @Composable
 fun ExclamationMarkIcon(
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
 ) {
     Image(
         painter = painterResource(id = R.drawable.ic_exclamation_mark),
         contentDescription = "Exclamation Mark Icon",
         modifier = modifier
+    )
+}
+
+@Composable
+fun TopEndArrowIcon(
+    modifier: Modifier = Modifier,
+) {
+    Image(
+        painter = painterResource(id = R.drawable.ic_top_end_arrow),
+        contentDescription = "화살표 아이콘",
+                modifier = modifier
     )
 }

--- a/design-system/src/main/java/com/msg/sms/design/util/addTitle.kt
+++ b/design-system/src/main/java/com/msg/sms/design/util/addTitle.kt
@@ -1,0 +1,47 @@
+package com.msg.sms.design.util
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.msg.sms.design.theme.SMSTheme
+
+@Composable
+fun Body1Text(titleText: String) {
+    SMSTheme { colors, typography ->
+        Text(
+            text = titleText,
+            style = typography.body1,
+            fontWeight = FontWeight.Normal,
+            color = colors.BLACK
+        )
+    }
+}
+
+@Composable
+fun AddBody1TitleText(
+    modifier: Modifier = Modifier,
+    titleText
+    : String,
+    spaceSize: Int = 16,
+    component: @Composable () -> Unit,
+) {
+    Column(modifier = modifier) {
+        Body1Text(titleText = titleText)
+        Spacer(modifier = Modifier.height(spaceSize.dp))
+        component()
+    }
+}
+
+@Preview
+@Composable
+fun AddTitlePre() {
+    AddBody1TitleText(titleText = "text") {
+        Text(text = "lsdjkf")
+    }
+}

--- a/design-system/src/main/java/com/msg/sms/design/util/addTitle.kt
+++ b/design-system/src/main/java/com/msg/sms/design/util/addTitle.kt
@@ -26,8 +26,7 @@ fun Body1Text(titleText: String) {
 @Composable
 fun AddBody1TitleText(
     modifier: Modifier = Modifier,
-    titleText
-    : String,
+    titleText: String,
     spaceSize: Int = 16,
     component: @Composable () -> Unit,
 ) {

--- a/design-system/src/main/res/drawable/ic_top_end_arrow.xml
+++ b/design-system/src/main/res/drawable/ic_top_end_arrow.xml
@@ -1,0 +1,13 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="10dp"
+    android:height="10dp"
+    android:viewportWidth="10"
+    android:viewportHeight="10">
+  <path
+      android:pathData="M3,1H9M9,1V7M9,1L1,9"
+      android:strokeLineJoin="round"
+      android:strokeWidth="2"
+      android:fillColor="#00000000"
+      android:strokeColor="#A5A6AC"
+      android:strokeLineCap="round"/>
+</vector>

--- a/domain/src/main/java/com/msg/sms/domain/model/student/response/GetStudentForAnonymous.kt
+++ b/domain/src/main/java/com/msg/sms/domain/model/student/response/GetStudentForAnonymous.kt
@@ -6,4 +6,6 @@ data class GetStudentForAnonymous(
     val major: String,
     val profileImg: String,
     val techStack: List<String>,
+    val projectList: List<String>,
+    val awardData: List<String>
 )

--- a/presentation/src/main/java/com/sms/presentation/main/ui/detail/AwardComponent.kt
+++ b/presentation/src/main/java/com/sms/presentation/main/ui/detail/AwardComponent.kt
@@ -1,0 +1,93 @@
+package com.sms.presentation.main.ui.detail
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.msg.sms.design.theme.SMSTheme
+import com.sms.presentation.main.ui.detail.data.AwardData
+
+@Composable
+fun AwardComponent(awardList: List<AwardData>) {
+    SMSTheme { colors, typography ->
+        LazyColumn(
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+            modifier = Modifier
+                .fillMaxWidth()
+                .heightIn(max = 10000.dp),
+            contentPadding = PaddingValues(bottom = 40.dp),
+            userScrollEnabled = false
+        ) {
+            item {
+                Text(
+                    text = "수상",
+                    style = typography.title2,
+                    color = colors.BLACK,
+                    fontWeight = FontWeight.Bold
+                )
+            }
+            items(awardList.size) {
+                val award = awardList[it]
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clip(RoundedCornerShape(8.dp))
+                        .background(colors.N10)
+                ) {
+                    Row(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .padding(8.dp)
+                            .align(Alignment.Center)
+                    ) {
+                        Column(modifier = Modifier.weight(1f)) {
+                            Text(
+                                text = award.title,
+                                style = typography.body1,
+                                color = colors.BLACK,
+                                fontWeight = FontWeight.Normal,
+                            )
+                            Spacer(modifier = Modifier.height(4.dp))
+                            Text(
+                                text = award.date,
+                                style = typography.caption2,
+                                fontWeight = FontWeight.Normal,
+                                color = colors.BLACK
+                            )
+                        }
+                        Text(
+                            text = award.organization,
+                            style = typography.caption2,
+                            fontWeight = FontWeight.Normal,
+                            color = colors.N40
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun AwardComponentPre() {
+    AwardComponent(awardList = listOf(AwardData("기업상", "해피문데이", "2023. 03. 02")))
+}

--- a/presentation/src/main/java/com/sms/presentation/main/ui/detail/ImportantTaskComponent.kt
+++ b/presentation/src/main/java/com/sms/presentation/main/ui/detail/ImportantTaskComponent.kt
@@ -1,0 +1,31 @@
+package com.sms.presentation.main.ui.detail
+
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.msg.sms.design.theme.SMSTheme
+import com.msg.sms.design.util.AddBody1TitleText
+
+@Composable
+fun ImportantTaskComponent(importantTask: String) {
+    AddBody1TitleText(titleText = "주요 작업 서술", spaceSize = 8, modifier = Modifier.heightIn(max = 1000.dp)) {
+        SMSTheme { colors, typography ->
+            Text(
+                text = importantTask,
+                style = typography.body2,
+                color = colors.N40,
+                fontWeight = FontWeight.Normal
+            )
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun ImportantTaskComponentPre() {
+    ImportantTaskComponent(importantTask = "저는 안드로이드 앱 개발 파트에서 이이이잉으로 이이이이이잉 했습니다. 히히 나이스")
+}

--- a/presentation/src/main/java/com/sms/presentation/main/ui/detail/StudentDetailComponent.kt
+++ b/presentation/src/main/java/com/sms/presentation/main/ui/detail/StudentDetailComponent.kt
@@ -232,7 +232,20 @@ private fun StudentDetailComponentPre() {
                 activityDuration = "2023 ~",
                 projectImage = listOf("https://avatars.githubusercontent.com/u/82383983?s=400&u=776e1d000088224cbabf4dec2bdea03071aaaef2&v=4"),
                 icon = "https://avatars.githubusercontent.com/u/82383983?s=400&u=776e1d000088224cbabf4dec2bdea03071aaaef2&v=4",
-                techStack = listOf("Github", "Git", "Kotlin", "Android Studio"),
+                techStack = listOf(
+                    "Github",
+                    "Git",
+                    "Kotlin",
+                    "Android Studio",
+                    "Github",
+                    "Git",
+                    "Kotlin",
+                    "Android Studio",
+                    "Github",
+                    "Git",
+                    "Kotlin",
+                    "Android Studio"
+                ),
                 keyTask = "모이자 ㅋㅋ",
                 relatedLinks = listOf(
                     RelatedLinksData("Youtube", "https://dolmc.com"),

--- a/presentation/src/main/java/com/sms/presentation/main/ui/detail/StudentDetailComponent.kt
+++ b/presentation/src/main/java/com/sms/presentation/main/ui/detail/StudentDetailComponent.kt
@@ -1,26 +1,41 @@
 package com.sms.presentation.main.ui.detail
 
+import android.content.Intent
+import android.net.Uri
 import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material.IconButton
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import com.msg.sms.design.component.button.SmsRoundedButton
 import com.msg.sms.design.component.item.TechStackItem
-import com.msg.sms.design.icon.BookIcon
 import com.msg.sms.design.theme.SMSTheme
 import com.msg.sms.domain.model.student.response.CertificationModel
+import com.sms.presentation.main.ui.detail.data.AwardData
+import com.sms.presentation.main.ui.detail.data.ProjectData
+import com.sms.presentation.main.ui.detail.data.RelatedLinksData
+import com.sms.presentation.main.ui.detail.project.ProjectListComponent
 import com.sms.presentation.main.ui.fill_out_information.data.CertificationData
 import com.sms.presentation.main.ui.fill_out_information.data.WorkConditionData
 
@@ -37,6 +52,8 @@ fun StudentDetailComponent(
     departments: String,
     introduce: String,
     portfolioLink: String,
+    awardData: List<AwardData>,
+    projectList: List<ProjectData>,
     gsmAuthenticationScore: String,
     email: String,
     militaryService: String,
@@ -47,9 +64,10 @@ fun StudentDetailComponent(
     foreignLanguage: List<CertificationModel>,
     isNotGuest: Boolean,
     isTeacher: Boolean,
-    onDreamBookButtonClick: (() -> Unit)?,
-    scrollState: ScrollState
+    scrollState: ScrollState = rememberScrollState(),
 ) {
+    val context = LocalContext.current
+
     Column(
         modifier = modifier
             .fillMaxWidth()
@@ -63,7 +81,7 @@ fun StudentDetailComponent(
         Box {
             Column(
                 modifier = Modifier
-                    .clip(RoundedCornerShape(24.dp))
+                    .clip(RoundedCornerShape(topEnd = 24.dp, topStart = 24.dp))
                     .background(Color.White)
             ) {
                 val itemModifier = Modifier.padding(horizontal = 20.dp)
@@ -130,7 +148,6 @@ fun StudentDetailComponent(
                 if (isTeacher) {
                     StudentInfoComponent(
                         modifier = itemModifier,
-                        portfolioLink = portfolioLink,
                         gsmAuthenticationScore = gsmAuthenticationScore,
                         email = email,
                         militaryService = militaryService,
@@ -143,17 +160,96 @@ fun StudentDetailComponent(
                         foreignLanguage = foreignLanguage
                     )
                 }
-            }
-            if (isTeacher) {
-                IconButton(
+                Column(
                     modifier = Modifier
-                        .align(Alignment.TopEnd)
-                        .padding(top = 20.dp, end = 20.dp),
-                    onClick = onDreamBookButtonClick!!
+                        .fillMaxWidth()
+                        .padding(start = 20.dp, end = 20.dp, bottom = 20.dp)
                 ) {
-                    BookIcon()
+                    AwardComponent(awardList = awardData)
+                    ProjectListComponent(projectList = projectList)
+                    SmsRoundedButton(
+                        text = "포트폴리오",
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(48.dp)
+                    ) {
+                        val urlIntent = Intent(
+                            Intent.ACTION_VIEW,
+                            Uri.parse(portfolioLink)
+                        )
+                        context.startActivity(urlIntent)
+                    }
                 }
             }
         }
     }
+}
+
+@Preview
+@Composable
+private fun StudentDetailComponentPre() {
+    StudentDetailComponent(
+        imageHeight = 300.dp,
+        major = "Android",
+        modifier = Modifier.heightIn(max = 1000.dp),
+        name = "이현빈",
+        techStack = listOf(
+            "Compose UI",
+            "Android Studio",
+            "Kotlin",
+            "Flutter",
+            "Dart",
+            "Compose for Web"
+        ),
+        grade = "3",
+        classNumber = "2",
+        schoolNumber = "15",
+        departments = "SW개발과",
+        introduce = "트렌드가 문화가 될 때까지",
+        portfolioLink = "https://",
+        awardData = listOf(AwardData("기업상", organization = "해피문데이", date = "2023. 08. 09")),
+        projectList = listOf(
+            ProjectData(
+                name = "SMS",
+                activityDuration = "2023 ~",
+                projectImage = listOf(
+                    "https://avatars.githubusercontent.com/u/82383983?s=400&u=776e1d000088224cbabf4dec2bdea03071aaaef2&v=4",
+                    "https://avatars.githubusercontent.com/u/82383983?s=400&u=776e1d000088224cbabf4dec2bdea03071aaaef2&v=4",
+                    "https://avatars.githubusercontent.com/u/82383983?s=400&u=776e1d000088224cbabf4dec2bdea03071aaaef2&v=4",
+                    "https://avatars.githubusercontent.com/u/82383983?s=400&u=776e1d000088224cbabf4dec2bdea03071aaaef2&v=4"
+                ),
+                icon = "https://avatars.githubusercontent.com/u/82383983?s=400&u=776e1d000088224cbabf4dec2bdea03071aaaef2&v=4",
+                techStack = listOf("Github", "Git", "Kotlin", "Android Studio"),
+                keyTask = "모이자 ㅋㅋ",
+                relatedLinks = listOf(
+                    RelatedLinksData("Youtube", "https://dolmc.com"),
+                    RelatedLinksData("GitHujb", "https://youyu.com"),
+                    RelatedLinksData("X", "https://asdgasgw.com")
+                )
+            ),
+            ProjectData(
+                name = "SMS",
+                activityDuration = "2023 ~",
+                projectImage = listOf("https://avatars.githubusercontent.com/u/82383983?s=400&u=776e1d000088224cbabf4dec2bdea03071aaaef2&v=4"),
+                icon = "https://avatars.githubusercontent.com/u/82383983?s=400&u=776e1d000088224cbabf4dec2bdea03071aaaef2&v=4",
+                techStack = listOf("Github", "Git", "Kotlin", "Android Studio"),
+                keyTask = "모이자 ㅋㅋ",
+                relatedLinks = listOf(
+                    RelatedLinksData("Youtube", "https://dolmc.com"),
+                    RelatedLinksData("GitHujb", "https://youyu.com"),
+                    RelatedLinksData("X", "https://asdgasgw.com")
+                )
+            )
+        ),
+        gsmAuthenticationScore = "800",
+        email = "dev.leehyeonbin@gmail.com",
+        militaryService = "힝",
+        formOfEmployment = "정직원",
+        salary = "4000",
+        region = listOf("서울"),
+        certificationData = listOf(),
+        foreignLanguage = listOf(),
+        isNotGuest = true,
+        isTeacher = true,
+    )
 }

--- a/presentation/src/main/java/com/sms/presentation/main/ui/detail/StudentDetailScreen.kt
+++ b/presentation/src/main/java/com/sms/presentation/main/ui/detail/StudentDetailScreen.kt
@@ -36,7 +36,6 @@ fun StudentDetailScreen(
     role: String,
     onDismissButtonClick: () -> Unit,
 ) {
-    val context = LocalContext.current
     val scrollState = rememberScrollState()
     val scope = rememberCoroutineScope()
 
@@ -86,14 +85,6 @@ fun StudentDetailScreen(
             departments = studentDetailData.department.departmentEnumToString(),
             introduce = studentDetailData.introduce,
             isTeacher = role == "ROLE_TEACHER",
-            onDreamBookButtonClick = {
-                val downloader = AndroidDownloader(
-                    context = context,
-                    fileName =
-                    "${studentDetailData.grade}${studentDetailData.classNum}${if (studentDetailData.number.toString().length == 1) "0" + studentDetailData.number else studentDetailData.number}${studentDetailData.name}의 드림북.hwp"
-                )
-                downloader.downloadFile(url = studentDetailData.dreamBookFileUrl)
-            },
             certificationData = studentDetailData.certificates,
             email = studentDetailData.contactEmail,
             gsmAuthenticationScore = studentDetailData.gsmAuthenticationScore.toString(),
@@ -103,7 +94,9 @@ fun StudentDetailScreen(
             portfolioLink = studentDetailData.portfolioUrl,
             region = studentDetailData.regions,
             salary = studentDetailData.salary.toString(),
-            scrollState = scrollState
+            scrollState = scrollState,
+            awardData = studentDetailData.awardData,
+            projectList = studentDetailData.projectList
         )
         IconButton(
             onClick = {

--- a/presentation/src/main/java/com/sms/presentation/main/ui/detail/StudentInfoComponent.kt
+++ b/presentation/src/main/java/com/sms/presentation/main/ui/detail/StudentInfoComponent.kt
@@ -1,14 +1,15 @@
 package com.sms.presentation.main.ui.detail
 
-import android.content.Intent
-import android.net.Uri
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
-import com.msg.sms.design.component.button.SmsRoundedButton
 import com.msg.sms.design.component.divider.SmsDivider
 import com.msg.sms.design.theme.SMSTheme
 import com.msg.sms.domain.model.student.response.CertificationModel
@@ -18,7 +19,6 @@ import com.sms.presentation.main.ui.fill_out_information.data.WorkConditionData
 @Composable
 fun StudentInfoComponent(
     modifier: Modifier,
-    portfolioLink: String,
     gsmAuthenticationScore: String,
     email: String,
     militaryService: String,
@@ -26,7 +26,6 @@ fun StudentInfoComponent(
     certificationData: CertificationData,
     foreignLanguage: List<CertificationModel>,
 ) {
-    val context = LocalContext.current
     val titleTextModifier = Modifier
         .fillMaxWidth(0.4f)
         .padding(vertical = 8.dp)
@@ -175,18 +174,7 @@ fun StudentInfoComponent(
                     }
                 }
             }
-            Spacer(modifier = Modifier.height(44.dp))
-            SmsRoundedButton(
-                text = "포트폴리오", modifier = Modifier
-                    .fillMaxWidth()
-                    .height(48.dp)
-            ) {
-                val urlIntent = Intent(
-                    Intent.ACTION_VIEW,
-                    Uri.parse(portfolioLink)
-                )
-                context.startActivity(urlIntent)
-            }
+            Spacer(modifier = Modifier.height(20.dp))
         }
     }
 }

--- a/presentation/src/main/java/com/sms/presentation/main/ui/detail/data/AwardData.kt
+++ b/presentation/src/main/java/com/sms/presentation/main/ui/detail/data/AwardData.kt
@@ -1,0 +1,7 @@
+package com.sms.presentation.main.ui.detail.data
+
+data class AwardData(
+    val title: String,
+    val organization: String,
+    val date: String
+)

--- a/presentation/src/main/java/com/sms/presentation/main/ui/detail/data/ProjectData.kt
+++ b/presentation/src/main/java/com/sms/presentation/main/ui/detail/data/ProjectData.kt
@@ -1,0 +1,11 @@
+package com.sms.presentation.main.ui.detail.data
+
+data class ProjectData(
+    val name: String,
+    val activityDuration: String,
+    val projectImage: List<String>,
+    val icon: String,
+    val techStack: List<String>,
+    val keyTask: String,
+    val relatedLinks: List<RelatedLinksData>
+)

--- a/presentation/src/main/java/com/sms/presentation/main/ui/detail/data/RelatedLinksData.kt
+++ b/presentation/src/main/java/com/sms/presentation/main/ui/detail/data/RelatedLinksData.kt
@@ -1,0 +1,6 @@
+package com.sms.presentation.main.ui.detail.data
+
+data class RelatedLinksData(
+    val name: String,
+    val link: String
+)

--- a/presentation/src/main/java/com/sms/presentation/main/ui/detail/link/LinkComponent.kt
+++ b/presentation/src/main/java/com/sms/presentation/main/ui/detail/link/LinkComponent.kt
@@ -4,7 +4,6 @@ import android.content.Context
 import android.content.Intent
 import android.net.Uri
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row

--- a/presentation/src/main/java/com/sms/presentation/main/ui/detail/link/LinkComponent.kt
+++ b/presentation/src/main/java/com/sms/presentation/main/ui/detail/link/LinkComponent.kt
@@ -1,6 +1,10 @@
 package com.sms.presentation.main.ui.detail.link
 
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -14,17 +18,19 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.msg.sms.design.icon.TopEndArrowIcon
+import com.msg.sms.design.modifier.smsClickable
 import com.msg.sms.design.theme.SMSTheme
 import com.sms.presentation.main.ui.detail.data.RelatedLinksData
 
 @Composable
-fun LinkComponent(linksData: RelatedLinksData, getHeight: (height: Dp) -> Unit) {
+fun LinkComponent(context: Context = LocalContext.current, linksData: RelatedLinksData, getHeight: (height: Dp) -> Unit) {
     SMSTheme { colors, typography ->
         Box(
             modifier = Modifier
@@ -32,6 +38,13 @@ fun LinkComponent(linksData: RelatedLinksData, getHeight: (height: Dp) -> Unit) 
                 .background(color = colors.N10)
                 .onGloballyPositioned {
                     getHeight(it.size.height.dp)
+                }
+                .smsClickable {
+                    val urlIntent = Intent(
+                        Intent.ACTION_VIEW,
+                        Uri.parse(linksData.link)
+                    )
+                    context.startActivity(urlIntent)
                 }
         ) {
             Row(

--- a/presentation/src/main/java/com/sms/presentation/main/ui/detail/link/LinkComponent.kt
+++ b/presentation/src/main/java/com/sms/presentation/main/ui/detail/link/LinkComponent.kt
@@ -1,0 +1,83 @@
+package com.sms.presentation.main.ui.detail.link
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.msg.sms.design.icon.TopEndArrowIcon
+import com.msg.sms.design.theme.SMSTheme
+import com.sms.presentation.main.ui.detail.data.RelatedLinksData
+
+@Composable
+fun LinkComponent(linksData: RelatedLinksData, getHeight: (height: Dp) -> Unit) {
+    SMSTheme { colors, typography ->
+        Box(
+            modifier = Modifier
+                .clip(RoundedCornerShape(8.dp))
+                .background(color = colors.N10)
+                .onGloballyPositioned {
+                    getHeight(it.size.height.dp)
+                }
+        ) {
+            Row(
+                Modifier
+                    .padding(8.dp)
+                    .fillMaxWidth()
+            ) {
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        text = linksData.name,
+                        style = typography.body1,
+                        fontWeight = FontWeight.Normal,
+                        color = colors.BLACK,
+                    )
+                    Spacer(modifier = Modifier.height(4.dp))
+                    Text(
+                        modifier = Modifier.fillMaxWidth(),
+                        text = linksData.link,
+                        maxLines = 1,
+                        style = typography.caption2,
+                        fontWeight = FontWeight.Normal,
+                        overflow = TextOverflow.Ellipsis,
+                        color = colors.N40,
+                    )
+                }
+                TopEndArrowIcon()
+            }
+
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun LinkComponentPre() {
+    LinkComponent(
+        linksData = RelatedLinksData(name = "Youtube", link = "https://youtube.com"),
+        getHeight = {})
+}
+
+@Preview
+@Composable
+private fun LongLinkComponentPre() {
+    LinkComponent(
+        linksData = RelatedLinksData(
+            name = "Youtube",
+            link = "https://youtube.com/lkajsdlfjal;sdlfnaosdjfkasodfjkao;rigjasdg;ljaworgji"
+        ), getHeight = {})
+}

--- a/presentation/src/main/java/com/sms/presentation/main/ui/detail/link/RelatedLinksComponent.kt
+++ b/presentation/src/main/java/com/sms/presentation/main/ui/detail/link/RelatedLinksComponent.kt
@@ -1,0 +1,44 @@
+package com.sms.presentation.main.ui.detail.link
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.sms.presentation.main.ui.detail.data.RelatedLinksData
+
+@Composable
+fun RelatedLinksComponent(modifier: Modifier = Modifier, links: List<RelatedLinksData>) {
+    val itemHeight = remember {
+        mutableStateOf(0.dp)
+    }
+    LazyColumn(
+        modifier = modifier.heightIn(max = 200.dp),
+        verticalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        items(links.size) {
+            LinkComponent(
+                linksData = links[it],
+                getHeight = { height -> itemHeight.value = height })
+        }
+    }
+}
+
+@Preview
+@Composable
+fun RelatedLinksComponentPre() {
+    RelatedLinksComponent(
+        links = listOf(
+            RelatedLinksData("Youtube", "https://dolmc.com"),
+            RelatedLinksData("GitHub", "https://youyu.com"),
+            RelatedLinksData(
+                "X",
+                "https://asdgasasdfljkasjhdlfalsdhfklhalksdhfklhaskldjfhlkasdhfklahsdfkjgw.com"
+            )
+        )
+    )
+}

--- a/presentation/src/main/java/com/sms/presentation/main/ui/detail/project/ProjectComponent.kt
+++ b/presentation/src/main/java/com/sms/presentation/main/ui/detail/project/ProjectComponent.kt
@@ -28,6 +28,7 @@ import androidx.compose.ui.unit.dp
 import coil.compose.rememberAsyncImagePainter
 import com.msg.sms.design.component.text.TechStackRow
 import com.msg.sms.design.theme.SMSTheme
+import com.msg.sms.design.util.AddBody1TitleText
 import com.sms.presentation.main.ui.detail.ImportantTaskComponent
 import com.sms.presentation.main.ui.detail.data.ProjectData
 import com.sms.presentation.main.ui.detail.data.RelatedLinksData
@@ -89,14 +90,9 @@ fun ProjectComponent(data: ProjectData) {
                     }
                 }
             }
-            Text(
-                text = "사용기술",
-                style = typography.body1,
-                color = colors.BLACK,
-                fontWeight = FontWeight.Normal
-            )
-            Spacer(modifier = Modifier.height(8.dp))
-            TechStackRow(modifier = Modifier, techStack = data.techStack)
+            AddBody1TitleText(titleText = "사용기술", spaceSize = 8) {
+                TechStackRow(modifier = Modifier, techStack = data.techStack)
+            }
             Spacer(modifier = Modifier.height(24.dp))
             ImportantTaskComponent(importantTask = data.keyTask)
             Spacer(modifier = Modifier.height(24.dp))

--- a/presentation/src/main/java/com/sms/presentation/main/ui/detail/project/ProjectComponent.kt
+++ b/presentation/src/main/java/com/sms/presentation/main/ui/detail/project/ProjectComponent.kt
@@ -1,0 +1,135 @@
+package com.sms.presentation.main.ui.detail.project
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.itemsIndexed
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import coil.compose.rememberAsyncImagePainter
+import com.msg.sms.design.component.text.TechStackRow
+import com.msg.sms.design.theme.SMSTheme
+import com.sms.presentation.main.ui.detail.ImportantTaskComponent
+import com.sms.presentation.main.ui.detail.data.ProjectData
+import com.sms.presentation.main.ui.detail.data.RelatedLinksData
+import com.sms.presentation.main.ui.detail.link.RelatedLinksComponent
+
+@Composable
+fun ProjectComponent(data: ProjectData) {
+    SMSTheme { colors, typography ->
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+        ) {
+            Row(modifier = Modifier.fillMaxWidth()) {
+                Image(
+                    painter = rememberAsyncImagePainter(model = data.icon),
+                    contentDescription = "${data.name} 아이콘",
+                    contentScale = ContentScale.Crop,
+                    modifier = Modifier
+                        .clip(RoundedCornerShape(8))
+                        .size(40.dp)
+                )
+                Spacer(modifier = Modifier.width(8.dp))
+                Column {
+                    Text(
+                        text = data.name,
+                        style = typography.body1,
+                        color = colors.BLACK,
+                        fontWeight = FontWeight.Normal
+                    )
+                    Text(
+                        text = data.activityDuration,
+                        style = typography.caption2,
+                        color = colors.BLACK,
+                        fontWeight = FontWeight.Normal
+                    )
+                }
+            }
+            Spacer(modifier = Modifier.height(8.dp))
+            BoxWithConstraints(modifier = Modifier.fillMaxWidth()) {
+                LazyVerticalGrid(
+                    userScrollEnabled = false,
+                    columns = GridCells.Fixed(2),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .heightIn(max = maxWidth + 100.dp),
+                    verticalArrangement = Arrangement.spacedBy(8.dp),
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    contentPadding = PaddingValues(bottom = 24.dp)
+                ) {
+                    itemsIndexed(data.projectImage) { _, item ->
+                        Image(
+                            painter = rememberAsyncImagePainter(model = item),
+                            contentDescription = "${data.name} 이미지",
+                            contentScale = ContentScale.Crop,
+                            modifier = Modifier
+                                .clip(RoundedCornerShape(8.dp))
+                                .aspectRatio(1f)
+                        )
+                    }
+                }
+            }
+            Text(
+                text = "사용기술",
+                style = typography.body1,
+                color = colors.BLACK,
+                fontWeight = FontWeight.Normal
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+            TechStackRow(modifier = Modifier, techStack = data.techStack)
+            Spacer(modifier = Modifier.height(24.dp))
+            ImportantTaskComponent(importantTask = data.keyTask)
+            Spacer(modifier = Modifier.height(24.dp))
+            RelatedLinksComponent(links = data.relatedLinks)
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun ProjectComponentPre() {
+    ProjectComponent(
+        data = ProjectData(
+            name = "SMS",
+            activityDuration = "2023 ~",
+            projectImage = listOf("https://avatars.githubusercontent.com/u/82383983?s=400&u=776e1d000088224cbabf4dec2bdea03071aaaef2&v=4"),
+            icon = "https://avatars.githubusercontent.com/u/82383983?s=400&u=776e1d000088224cbabf4dec2bdea03071aaaef2&v=4",
+            techStack = listOf(
+                "Github",
+                "Git",
+                "Kotlin",
+                "Android Studio",
+                "Kotlin",
+                "Android Studio",
+                "Kotlin",
+                "Android Studio"
+            ),
+            keyTask = "모이자 ㅋㅋ",
+            relatedLinks = listOf(
+                RelatedLinksData("Youtube", "https://dolmc.com"),
+                RelatedLinksData("GitHujb", "https://youyu.com"),
+                RelatedLinksData("X", "https://asdgasgw.com")
+            )
+        )
+    )
+}

--- a/presentation/src/main/java/com/sms/presentation/main/ui/detail/project/ProjectListComponent.kt
+++ b/presentation/src/main/java/com/sms/presentation/main/ui/detail/project/ProjectListComponent.kt
@@ -1,0 +1,85 @@
+package com.sms.presentation.main.ui.detail.project
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.msg.sms.design.theme.SMSTheme
+import com.sms.presentation.main.ui.detail.data.ProjectData
+import com.sms.presentation.main.ui.detail.data.RelatedLinksData
+
+@Composable
+fun ProjectListComponent(
+    projectList: List<ProjectData>,
+) {
+    SMSTheme { colors, typography ->
+        LazyColumn(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding()
+                .heightIn(max = 10000.dp),
+            contentPadding = PaddingValues(bottom = 80.dp),
+            verticalArrangement = Arrangement.spacedBy(32.dp)
+        ) {
+            item {
+                Text(
+                    text = "프로젝트",
+                    style = typography.title2,
+                    color = colors.BLACK,
+                    fontWeight = FontWeight.Bold
+                )
+            }
+            items(projectList.size) {
+                ProjectComponent(data = projectList[it])
+            }
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun ProjectComponentPre() {
+    ProjectListComponent(
+        projectList = listOf(
+            ProjectData(
+                name = "SMS",
+                activityDuration = "2023 ~",
+                projectImage = listOf(
+                    "https://avatars.githubusercontent.com/u/82383983?s=400&u=776e1d000088224cbabf4dec2bdea03071aaaef2&v=4",
+                    "https://avatars.githubusercontent.com/u/82383983?s=400&u=776e1d000088224cbabf4dec2bdea03071aaaef2&v=4",
+                    "https://avatars.githubusercontent.com/u/82383983?s=400&u=776e1d000088224cbabf4dec2bdea03071aaaef2&v=4",
+                    "https://avatars.githubusercontent.com/u/82383983?s=400&u=776e1d000088224cbabf4dec2bdea03071aaaef2&v=4"
+                ),
+                icon = "https://avatars.githubusercontent.com/u/82383983?s=400&u=776e1d000088224cbabf4dec2bdea03071aaaef2&v=4",
+                techStack = listOf("Github", "Git", "Kotlin", "Android Studio"),
+                keyTask = "모이자 ㅋㅋ",
+                relatedLinks = listOf(
+                    RelatedLinksData("Youtube", "https://dolmc.com"),
+                    RelatedLinksData("GitHujb", "https://youyu.com"),
+                    RelatedLinksData("X", "https://asdgasgw.com")
+                )
+            ),
+            ProjectData(
+                name = "SMS",
+                activityDuration = "2023 ~",
+                projectImage = listOf("https://avatars.githubusercontent.com/u/82383983?s=400&u=776e1d000088224cbabf4dec2bdea03071aaaef2&v=4"),
+                icon = "https://avatars.githubusercontent.com/u/82383983?s=400&u=776e1d000088224cbabf4dec2bdea03071aaaef2&v=4",
+                techStack = listOf("Github", "Git", "Kotlin", "Android Studio"),
+                keyTask = "모이자 ㅋㅋ",
+                relatedLinks = listOf(
+                    RelatedLinksData("Youtube", "https://dolmc.com"),
+                    RelatedLinksData("GitHujb", "https://youyu.com"),
+                    RelatedLinksData("X", "https://asdgasgw.com")
+                )
+            )
+        )
+    )
+}

--- a/presentation/src/main/java/com/sms/presentation/main/ui/filter/component/FilterSelectorComponent.kt
+++ b/presentation/src/main/java/com/sms/presentation/main/ui/filter/component/FilterSelectorComponent.kt
@@ -1,36 +1,31 @@
 package com.sms.presentation.main.ui.filter.component
 
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
-import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import com.msg.sms.design.theme.SMSTheme
+import com.msg.sms.design.util.AddBody1TitleText
 
 @Composable
 fun <T> FilterSelectorComponent(
     title: String,
     itemList: List<T>,
     selectedList: List<T>,
-    onItemSelected: (checked: Boolean, value: T) -> Unit
+    onItemSelected: (checked: Boolean, value: T) -> Unit,
 ) {
-
-    SMSTheme { colors, typography ->
-        Column(
-            modifier = Modifier
-                .padding(horizontal = 20.dp)
-                .heightIn(max = 300.dp)
-        ) {
-            Text(
-                text = title,
-                style = typography.body1,
-                color = colors.BLACK,
-                fontWeight = FontWeight.Normal
-            )
-            Spacer(modifier = Modifier.height(16.dp))
+    Column(
+        modifier = Modifier
+            .padding(horizontal = 20.dp)
+            .heightIn(max = 300.dp)
+    ) {
+        AddBody1TitleText(titleText = title) {
             LazyVerticalGrid(
                 columns = GridCells.Adaptive(minSize = 150.dp),
                 userScrollEnabled = false
@@ -49,4 +44,14 @@ fun <T> FilterSelectorComponent(
             }
         }
     }
+}
+
+@Preview
+@Composable
+fun FilterSelectorComponentPre() {
+    FilterSelectorComponent(
+        title = "text",
+        itemList = listOf("aa", "bb", "cc"),
+        selectedList = listOf("aa"),
+        onItemSelected = { checked: Boolean, value: String -> })
 }

--- a/presentation/src/main/java/com/sms/presentation/main/ui/main/data/StudentDetailData.kt
+++ b/presentation/src/main/java/com/sms/presentation/main/ui/main/data/StudentDetailData.kt
@@ -1,6 +1,8 @@
 package com.sms.presentation.main.ui.main.data
 
 import com.msg.sms.domain.model.student.response.CertificationModel
+import com.sms.presentation.main.ui.detail.data.AwardData
+import com.sms.presentation.main.ui.detail.data.ProjectData
 
 data class StudentDetailData(
     val name: String = "",
@@ -21,5 +23,7 @@ data class StudentDetailData(
     val salary: Int = 0,
     val languageCertificates: List<CertificationModel> = listOf(),
     val certificates: List<String> = listOf(),
-    val techStacks: List<String> = listOf()
+    val techStacks: List<String> = listOf(),
+    val awardData: List<AwardData> = listOf(),
+    val projectList: List<ProjectData> = listOf()
 )

--- a/presentation/src/main/java/com/sms/presentation/main/ui/main/screen/MainScreen.kt
+++ b/presentation/src/main/java/com/sms/presentation/main/ui/main/screen/MainScreen.kt
@@ -317,13 +317,16 @@ fun MainScreen(
                                     },
                                     {
                                         isDetailBottomSheet.value = true
-                                        studentDetailData.value = StudentDetailData(
-                                            name = it.name,
-                                            introduce = it.introduce,
-                                            major = it.major,
-                                            profileImg = it.profileImg,
-                                            techStacks = it.techStack
-                                        )
+                                        // Todo(LeeHyeonbin): 디테일 페이지 API 수정하면서 여기 변경하기
+//                                        studentDetailData.value = StudentDetailData(
+//                                            name = it.name,
+//                                            introduce = it.introduce,
+//                                            major = it.major,
+//                                            profileImg = it.profileImg,
+//                                            techStacks = it.techStack,
+//                                            awardData = it.awardData,
+//                                            projectList = it.projectList
+//                                        )
                                         scope.launch {
                                             bottomSheetState.show()
                                         }


### PR DESCRIPTION
## 💡 개요
디테일 페이지가 수정됨에 따라 퍼블리싱을 변경합니다.

## 📃 작업내용
https://github.com/GSM-MSG/SMS-Android/assets/82383983/b060a040-d9bd-4ed7-9e0e-45d5956de04b
여기 영상에 프로필이 나오지 않은 이유는 컴포넌트를 하나 덜 들어가서 그래요. 만약 스크린에서 실행해서 문제 생기면 바로 해결할게요

## 🔀 변경사항
* 기존의 드림북 제거,
* 리스트 형태의 프로젝트 추가
* 수상 이력 추가
* 기존의 Title과 Spacer를 넣던 로직을 좀 더 간편하게 컴포넌트로 생성

## 🎸  더 해야할 일
* 저기에 API 부분이 어찌 될지 몰라서 일단 Todo 처리 해놓은 부분 수정해야함
* 그 지금 보면 heightIn이 계산을 하지 않고 대충 큰 수로 잡아놓은 경우들이 좀 있어서, 데이터가 어느정도 크기로 들어갈 지 확인해서 수정해야함.
