### PR TITLE
🔀 ::  (#262) - version conflict resolve

### DIFF
--- a/buildSrc/src/main/java/Versions.kt
+++ b/buildSrc/src/main/java/Versions.kt
@@ -11,7 +11,6 @@ object Versions {
     const val COMPOSE_MATERIAL3 = "1.1.1"
 
     const val SPLASH = "1.0.1"
-    const val CORE_KTX = "1.7.0"
     const val LIFECYCLE = "2.6.1"
     const val CORE_KTX = "1.10.1"
     const val MATERIAL = "1.8.0"


### PR DESCRIPTION
## 💡 개요
충돌나면서 중간에 예전 버전이 안지워진 듯 하네요.
지금처럼 분리하는 것도 좋지만, 많은 버전 업이 일어나면 문제가 또 생길 수 있으니 적당히 파일을 분리하는 편이 좋아보이네요