### PR TITLE
🔀 :: (#270) - 프로젝트 프리뷰 갤러리 다중선택으로 변경

### DIFF
--- a/design-system/src/main/java/com/msg/sms/design/modifier/smsClickable.kt
+++ b/design-system/src/main/java/com/msg/sms/design/modifier/smsClickable.kt
@@ -7,15 +7,19 @@ import androidx.compose.material.ripple.rememberRipple
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
 
 @OptIn(ExperimentalFoundationApi::class)
 fun Modifier.smsClickable(
     rippleEnabled: Boolean = true,
+    bounded: Boolean = true,
+    radius: Dp = 15.dp,
     onClick: () -> Unit
 ) = composed {
     combinedClickable(
         onClick = onClick,
         interactionSource = remember { MutableInteractionSource() },
-        indication = if (rippleEnabled) rememberRipple(bounded = true) else null
+        indication = if (rippleEnabled) rememberRipple(bounded = bounded, radius = radius) else null
     )
 }

--- a/design-system/src/main/java/com/msg/sms/design/modifier/smsClickable.kt
+++ b/design-system/src/main/java/com/msg/sms/design/modifier/smsClickable.kt
@@ -3,20 +3,21 @@ package com.msg.sms.design.modifier
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.material.ripple.rememberRipple
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
 import androidx.compose.ui.unit.Dp
-import androidx.compose.ui.unit.dp
 
 @OptIn(ExperimentalFoundationApi::class)
 fun Modifier.smsClickable(
     rippleEnabled: Boolean = true,
     bounded: Boolean = true,
-    radius: Dp = 15.dp,
+    radius: Dp = Dp.Unspecified,
     onClick: () -> Unit
 ) = composed {
+    this.wrapContentSize()
     combinedClickable(
         onClick = onClick,
         interactionSource = remember { MutableInteractionSource() },

--- a/presentation/src/main/java/com/sms/presentation/main/ui/fill_out_information/component/ProjectPreviewInputComponent.kt
+++ b/presentation/src/main/java/com/sms/presentation/main/ui/fill_out_information/component/ProjectPreviewInputComponent.kt
@@ -7,7 +7,6 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.IconButton
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment

--- a/presentation/src/main/java/com/sms/presentation/main/ui/fill_out_information/component/ProjectPreviewInputComponent.kt
+++ b/presentation/src/main/java/com/sms/presentation/main/ui/fill_out_information/component/ProjectPreviewInputComponent.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.IconButton
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -71,7 +72,9 @@ fun ProjectPreviewInputComponent(
                             modifier = Modifier
                                 .align(Alignment.TopEnd)
                                 .padding(6.dp)
-                                .smsClickable { deletedIndex(idx) }
+                                .smsClickable(
+                                    bounded = false
+                                ) { deletedIndex(idx) }
                         )
                     }
                 }

--- a/presentation/src/main/java/com/sms/presentation/main/ui/fill_out_information/screen/ProjectsScreen.kt
+++ b/presentation/src/main/java/com/sms/presentation/main/ui/fill_out_information/screen/ProjectsScreen.kt
@@ -4,6 +4,7 @@ import android.Manifest
 import android.net.Uri
 import android.os.Build
 import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.PickVisualMediaRequest
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
@@ -37,6 +38,7 @@ fun ProjectsScreen(
     bottomSheetState: ModalBottomSheetState,
     bottomSheetContent: @Composable (content: @Composable ColumnScope.() -> Unit) -> Unit
 ) {
+    val context = LocalContext.current
     val coroutineScope = rememberCoroutineScope()
     val projectName = remember {
         mutableStateOf("")
@@ -71,27 +73,39 @@ fun ProjectsScreen(
     val isProjectStartDate = remember {
         mutableStateOf(true)
     }
-    val context = LocalContext.current
-
-    val galleryLauncher =
-        rememberLauncherForActivityResult(ActivityResultContracts.GetContent()) { uri ->
+    val singleSelectGalleryLauncher =
+        rememberLauncherForActivityResult(ActivityResultContracts.PickVisualMedia()) { uri ->
             if (uri != null) {
                 if (getFileNameFromUri(context, uri)!!.isImageExtensionCorrect()) {
                     isImageExtensionInCorrect.value = false
-                    if (isImportingProjectIcons.value) {
-                        projectIconUri.value = uri
-                    } else {
-                        if (projectPreviewUriList.size < 4) projectPreviewUriList.add(uri)
-                    }
+                    projectIconUri.value = uri
                 } else {
                     isImageExtensionInCorrect.value = true
                 }
             }
         }
+    val multipleSelectGalleryLauncher =
+        rememberLauncherForActivityResult(ActivityResultContracts.PickMultipleVisualMedia(maxItems = 4)) { uris ->
+            if (uris.isNotEmpty()) {
+                if (uris.all { uri -> getFileNameFromUri(context, uri)?.isImageExtensionCorrect() == true }) {
+                    isImageExtensionInCorrect.value = false
+                    projectPreviewUriList.clear()
+                    projectPreviewUriList.addAll(uris)
+                } else {
+                    isImageExtensionInCorrect.value = true
+                }
+            }
+        }
+
     val permissionLauncher = rememberLauncherForActivityResult(
         ActivityResultContracts.RequestPermission()
     ) { isGranted ->
-        if (isGranted) galleryLauncher.launch("image/*")
+        if (isGranted) {
+            if (isImportingProjectIcons.value)
+                singleSelectGalleryLauncher.launch(PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly))
+            else
+                multipleSelectGalleryLauncher.launch(PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly))
+        }
     }
 
     val permission =


### PR DESCRIPTION
## 💡 개요
- 프로젝트 프리뷰 갤러리 방식을 다중선택으로 변경합니다.

## 🔀 변경사항
- 프로젝트 프리뷰 갤러리 방식 다중선택으로 변경
- 기존 갤러리 접근인 GetContent에서 PickVisualMedia 방식으로 변경
- 사용자가 bounded 및 리플 크기를 지정할 수 있도록 smsClickable업데이트

## 영상

https://github.com/GSM-MSG/SMS-Android/assets/80810303/89209a51-8f63-420e-bf2c-d86cbfc6b704

