### PR TITLE
🔀 :: (#279) - create the state of certification and foreign language section on my page

### DIFF
--- a/presentation/src/main/java/com/sms/presentation/main/ui/mypage/MyPageComponent.kt
+++ b/presentation/src/main/java/com/sms/presentation/main/ui/mypage/MyPageComponent.kt
@@ -55,6 +55,9 @@ fun MyPageComponent(
     val wantWorkingArea = remember {
         mutableStateListOf(*listOf("광저우", "충칭", "하노이", "도쿄").toTypedArray())
     }
+    val foreignLanguages = remember {
+        mutableStateListOf(*listOf(Pair("한국어", "원어민"), Pair("토익", "990")).toTypedArray())
+    }
 
     Box(
         modifier = Modifier.fillMaxWidth()
@@ -127,7 +130,18 @@ fun MyPageComponent(
                 TitleHeader(titleText = "외국어")
             }
             item {
-                ForeignLanguagesSection()
+                ForeignLanguagesSection(
+                    foreignLanguages = foreignLanguages,
+                    onValueChangeForeignName = { index, value ->
+                        foreignLanguages[index] = foreignLanguages[index].copy(first = value)
+                    },
+                    onValueChangeForeignValue = { index, value ->
+                        foreignLanguages[index] = foreignLanguages[index].copy(second = value)
+                    },
+                    onClickRemoveButton = { foreignLanguages.removeAt(it) }
+                ) {
+                    foreignLanguages.add(Pair("", ""))
+                }
                 SmsSpacer()
             }
             listOf("프로젝트 1", "프로젝트 2").forEachIndexed { index, it ->

--- a/presentation/src/main/java/com/sms/presentation/main/ui/mypage/MyPageComponent.kt
+++ b/presentation/src/main/java/com/sms/presentation/main/ui/mypage/MyPageComponent.kt
@@ -58,6 +58,9 @@ fun MyPageComponent(
     val foreignLanguages = remember {
         mutableStateListOf(*listOf(Pair("한국어", "원어민"), Pair("토익", "990")).toTypedArray())
     }
+    val certifications = remember {
+        mutableStateListOf(*listOf("정보처리 산업기사").toTypedArray())
+    }
 
     Box(
         modifier = Modifier.fillMaxWidth()
@@ -123,7 +126,12 @@ fun MyPageComponent(
                 TitleHeader(titleText = "자격증")
             }
             item {
-                CertificationsSection()
+                CertificationsSection(
+                    certifications = certifications,
+                    onValueChange = { index, value -> certifications[index] = value },
+                    onClickRemoveButton = { certifications.removeAt(index = it)},
+                    onClickAddButton = { certifications.add("") }
+                )
                 SmsSpacer()
             }
             stickyHeader {

--- a/presentation/src/main/java/com/sms/presentation/main/ui/mypage/component/certification/CertificationsComponent.kt
+++ b/presentation/src/main/java/com/sms/presentation/main/ui/mypage/component/certification/CertificationsComponent.kt
@@ -6,7 +6,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.material.IconButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -19,7 +19,12 @@ import com.msg.sms.design.icon.TrashCanIcon
 import com.msg.sms.design.util.AddGrayBody1Title
 
 @Composable
-fun CertificationsComponent(certificationList: List<String>) {
+fun CertificationsComponent(
+    certifications: List<String>,
+    onValueChange: (index: Int, value: String) -> Unit,
+    onClickRemoveButton: (index: Int) -> Unit,
+    onClickAddButton: () -> Unit,
+) {
     AddGrayBody1Title(titleText = "자격증") {
         LazyColumn(
             modifier = Modifier
@@ -27,7 +32,7 @@ fun CertificationsComponent(certificationList: List<String>) {
                 .heightIn(max = 900.dp),
             verticalArrangement = Arrangement.spacedBy(8.dp)
         ) {
-            items(certificationList) {
+            itemsIndexed(certifications) { index, certification ->
                 Row(
                     modifier = Modifier.fillMaxWidth(),
                     horizontalArrangement = Arrangement.spacedBy(8.dp),
@@ -35,21 +40,21 @@ fun CertificationsComponent(certificationList: List<String>) {
                 ) {
                     Box(modifier = Modifier.weight(1f)) {
                         SmsTextField(
-                            setText = it,
-                            modifier = Modifier.fillMaxWidth()
+                            setText = certification,
+                            modifier = Modifier.fillMaxWidth(),
+                            onValueChange = { onValueChange(index, it) },
+                            placeHolder = "정보처리 산업기사"
                         ) {
-
+                            onValueChange(index, "")
                         }
                     }
-                    IconButton(onClick = { /*TODO*/ }) {
+                    IconButton(onClick = { onClickRemoveButton(index) }) {
                         TrashCanIcon()
                     }
                 }
             }
             item {
-                SmsChip(text = "추가") {
-
-                }
+                SmsChip(text = "추가", onClick = onClickAddButton)
             }
         }
     }
@@ -58,5 +63,9 @@ fun CertificationsComponent(certificationList: List<String>) {
 @Preview
 @Composable
 private fun CertificationsComponentPre() {
-    CertificationsComponent(listOf("정보처리 산업기사"))
+    CertificationsComponent(
+        listOf("정보처리 산업기사"),
+        onValueChange = { _, _ -> },
+        onClickRemoveButton = {},
+        onClickAddButton = {})
 }

--- a/presentation/src/main/java/com/sms/presentation/main/ui/mypage/component/language/ForeignLanguagesComponent.kt
+++ b/presentation/src/main/java/com/sms/presentation/main/ui/mypage/component/language/ForeignLanguagesComponent.kt
@@ -6,7 +6,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.material.IconButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -18,7 +18,13 @@ import com.msg.sms.design.icon.TrashCanIcon
 import com.msg.sms.design.util.AddGrayBody1Title
 
 @Composable
-fun ForeignLanguagesComponent(foreignLanguages: List<Pair<String, String>>) {
+fun ForeignLanguagesComponent(
+    foreignLanguages: List<Pair<String, String>>,
+    onValueChangeForeignName: (index: Int, value: String) -> Unit,
+    onValueChangeForeignValue: (index: Int, value: String) -> Unit,
+    onClickRemoveButton: (index: Int) -> Unit,
+    onClickAddButton: () -> Unit,
+) {
     AddGrayBody1Title(titleText = "외국어") {
         LazyColumn(
             modifier = Modifier
@@ -26,7 +32,7 @@ fun ForeignLanguagesComponent(foreignLanguages: List<Pair<String, String>>) {
                 .heightIn(max = 600.dp),
             verticalArrangement = Arrangement.spacedBy(8.dp)
         ) {
-            items(foreignLanguages) {
+            itemsIndexed(foreignLanguages) { index, foreignLanguage ->
                 Row(
                     modifier = Modifier.fillMaxWidth(),
                     horizontalArrangement = Arrangement.spacedBy(8.dp)
@@ -40,27 +46,27 @@ fun ForeignLanguagesComponent(foreignLanguages: List<Pair<String, String>>) {
                                 modifier = Modifier.fillMaxWidth(0.64f),
                                 singleLine = true,
                                 placeHolder = "예) 토익",
-                                setChangeText = ""
+                                setChangeText = foreignLanguage.first,
+                                onValueChange = { onValueChangeForeignName(index, it) }
                             )
                             Box(modifier = Modifier.weight(1f)) {
                                 NoneIconTextField(
                                     modifier = Modifier.fillMaxWidth(),
                                     singleLine = true,
                                     placeHolder = "990",
-                                    setChangeText = ""
+                                    setChangeText = foreignLanguage.second,
+                                    onValueChange = { onValueChangeForeignValue(index, it) }
                                 )
                             }
                         }
                     }
-                    IconButton(onClick = { /*TODO*/ }) {
+                    IconButton(onClick = { onClickRemoveButton(index) }) {
                         TrashCanIcon()
                     }
                 }
             }
             item {
-                SmsChip(text = "추가") {
-
-                }
+                SmsChip(text = "추가", onClick = onClickAddButton)
             }
         }
     }
@@ -69,5 +75,9 @@ fun ForeignLanguagesComponent(foreignLanguages: List<Pair<String, String>>) {
 @Preview
 @Composable
 fun ForeignLanguagesComponentPre() {
-    ForeignLanguagesComponent(listOf(Pair("토익", "990"), Pair("JLPT", "3급")))
+    ForeignLanguagesComponent(
+        listOf(Pair("토익", "990"), Pair("JLPT", "3급")),
+        onValueChangeForeignName = { _, _ -> },
+        onValueChangeForeignValue = { _, _ -> },
+        onClickRemoveButton = {}) {}
 }

--- a/presentation/src/main/java/com/sms/presentation/main/ui/mypage/section/CertificationsSection.kt
+++ b/presentation/src/main/java/com/sms/presentation/main/ui/mypage/section/CertificationsSection.kt
@@ -10,18 +10,33 @@ import androidx.compose.ui.unit.dp
 import com.sms.presentation.main.ui.mypage.component.certification.CertificationsComponent
 
 @Composable
-fun CertificationsSection() {
+fun CertificationsSection(
+    certifications: List<String>,
+    onValueChange: (index: Int, value: String) -> Unit,
+    onClickRemoveButton: (index: Int) -> Unit,
+    onClickAddButton: () -> Unit,
+) {
     Column(
         modifier = Modifier
             .fillMaxWidth()
             .padding(start = 20.dp, top = 24.dp, end = 20.dp, bottom = 20.dp)
     ) {
-        CertificationsComponent(certificationList = listOf("정보처리 산업기사"))
+        CertificationsComponent(
+            certifications = certifications,
+            onValueChange = onValueChange,
+            onClickRemoveButton = onClickRemoveButton,
+            onClickAddButton = onClickAddButton
+        )
     }
 }
 
 @Preview
 @Composable
 private fun CertificationsSectionPre() {
-    CertificationsSection()
+    CertificationsSection(
+        certifications = listOf("정보처리 산업기사"),
+        onValueChange = { _, _ -> },
+        onClickAddButton = {},
+        onClickRemoveButton = {}
+    )
 }

--- a/presentation/src/main/java/com/sms/presentation/main/ui/mypage/section/ForeignLanguagesSection.kt
+++ b/presentation/src/main/java/com/sms/presentation/main/ui/mypage/section/ForeignLanguagesSection.kt
@@ -10,18 +10,36 @@ import androidx.compose.ui.unit.dp
 import com.sms.presentation.main.ui.mypage.component.language.ForeignLanguagesComponent
 
 @Composable
-fun ForeignLanguagesSection() {
+fun ForeignLanguagesSection(
+    foreignLanguages: List<Pair<String, String>>,
+    onValueChangeForeignValue: (index: Int, value: String) -> Unit,
+    onValueChangeForeignName: (index: Int, value: String) -> Unit,
+    onClickRemoveButton: (index: Int) -> Unit,
+    onClickAddButton: () -> Unit,
+) {
     Column(
         modifier = Modifier
             .fillMaxWidth()
             .padding(start = 20.dp, top = 24.dp, end = 20.dp, bottom = 20.dp)
     ) {
-        ForeignLanguagesComponent(foreignLanguages = listOf(Pair("토익", "990"), Pair("JLPT", "3급")))
+        ForeignLanguagesComponent(
+            foreignLanguages = foreignLanguages,
+            onValueChangeForeignValue = onValueChangeForeignValue,
+            onValueChangeForeignName = onValueChangeForeignName,
+            onClickRemoveButton = onClickRemoveButton,
+            onClickAddButton = onClickAddButton
+        )
     }
 }
 
 @Preview
 @Composable
 private fun ForeignLanguagesSectionPre() {
-    ForeignLanguagesSection()
+    ForeignLanguagesSection(
+        listOf(Pair("한국어", "원어민"), Pair("토익", "990")),
+        onValueChangeForeignName = { _, _ -> },
+        onValueChangeForeignValue = { _, _ -> },
+        onClickRemoveButton = {},
+        onClickAddButton = {}
+    )
 }


### PR DESCRIPTION
## 💡 개요
* 자격증의 정보를 관리하는 부분의 수정, 삭제, 추가 기능을 구현합니다.
* 외국어의 정보를 관리하는 부분의 수정, 삭제, 추가 기능을 구현합니다.


https://github.com/GSM-MSG/SMS-Android/assets/82383983/a9af4e61-d513-482f-8d70-152d7615c9ce

