### PR TITLE
🔀 :: (#288) - 정보기입 관련 로직 수정

### DIFF
--- a/data/src/main/java/com/msg/sms/data/remote/dto/student/request/CertificateData.kt
+++ b/data/src/main/java/com/msg/sms/data/remote/dto/student/request/CertificateData.kt
@@ -1,6 +1,6 @@
 package com.msg.sms.data.remote.dto.student.request
 
-data class CertificateInformation(
+data class CertificateData(
     val languageCertificateName: String,
     val score: String
 )

--- a/data/src/main/java/com/msg/sms/data/remote/dto/student/request/EnterStudentInformationRequest.kt
+++ b/data/src/main/java/com/msg/sms/data/remote/dto/student/request/EnterStudentInformationRequest.kt
@@ -11,7 +11,7 @@ data class EnterStudentInformationRequest(
     val gsmAuthenticationScore: Int,
     val salary: Int,
     val region: List<String>,
-    val languageCertificate: List<CertificateInformation>,
+    val languageCertificate: List<CertificateData>,
     val militaryService: String,
     val certificate: List<String>
 )

--- a/data/src/main/java/com/msg/sms/data/remote/dto/student/request/EnterStudentInformationRequest.kt
+++ b/data/src/main/java/com/msg/sms/data/remote/dto/student/request/EnterStudentInformationRequest.kt
@@ -1,17 +1,36 @@
 package com.msg.sms.data.remote.dto.student.request
 
+import com.google.gson.annotations.SerializedName
+
 data class EnterStudentInformationRequest(
+    @SerializedName("major")
     val major: String,
+    @SerializedName("techStack")
     val techStack: List<String>,
+    @SerializedName("profileImgUrl")
     val profileImgUrl: String,
+    @SerializedName("introduce")
     val introduce: String,
+    @SerializedName("portfolioUrl")
     val portfolioUrl: String,
+    @SerializedName("contactEmail")
     val contactEmail: String,
+    @SerializedName("formOfEmployment")
     val formOfEmployment: String,
+    @SerializedName("gsmAuthenticationScore")
     val gsmAuthenticationScore: Int,
+    @SerializedName("salary")
     val salary: Int,
+    @SerializedName("region")
     val region: List<String>,
+    @SerializedName("languageCertificate")
     val languageCertificate: List<CertificateData>,
+    @SerializedName("militaryService")
     val militaryService: String,
-    val certificate: List<String>
+    @SerializedName("certificate")
+    val certificate: List<String>,
+    @SerializedName("projects")
+    val projects: List<ProjectData>,
+    @SerializedName("prize")
+    val prize: List<PrizeData>
 )

--- a/data/src/main/java/com/msg/sms/data/remote/dto/student/request/PrizeData.kt
+++ b/data/src/main/java/com/msg/sms/data/remote/dto/student/request/PrizeData.kt
@@ -1,0 +1,12 @@
+package com.msg.sms.data.remote.dto.student.request
+
+import com.google.gson.annotations.SerializedName
+
+data class PrizeData(
+    @SerializedName("name")
+    val name: String,
+    @SerializedName("type")
+    val type: String,
+    @SerializedName("date")
+    val date: String
+)

--- a/data/src/main/java/com/msg/sms/data/remote/dto/student/request/ProjectData.kt
+++ b/data/src/main/java/com/msg/sms/data/remote/dto/student/request/ProjectData.kt
@@ -1,0 +1,22 @@
+package com.msg.sms.data.remote.dto.student.request
+
+import com.google.gson.annotations.SerializedName
+
+data class ProjectData(
+    @SerializedName("name")
+    val name: String,
+    @SerializedName("icon")
+    val icon: String,
+    @SerializedName("previewImages")
+    val previewImages: List<String>,
+    @SerializedName("description")
+    val description: String,
+    @SerializedName("links")
+    val links: List<ProjectRelatedLinkData>,
+    @SerializedName("techStacks")
+    val techStacks: List<String>,
+    @SerializedName("myActivity")
+    val myActivity: String,
+    @SerializedName("inProgress")
+    val inProgress: ProjectDateData
+)

--- a/data/src/main/java/com/msg/sms/data/remote/dto/student/request/ProjectDateData.kt
+++ b/data/src/main/java/com/msg/sms/data/remote/dto/student/request/ProjectDateData.kt
@@ -1,0 +1,10 @@
+package com.msg.sms.data.remote.dto.student.request
+
+import com.google.gson.annotations.SerializedName
+
+data class ProjectDateData(
+    @SerializedName("start")
+    val start: String,
+    @SerializedName("end")
+    val end: String
+)

--- a/data/src/main/java/com/msg/sms/data/remote/dto/student/request/ProjectRelatedLinkData.kt
+++ b/data/src/main/java/com/msg/sms/data/remote/dto/student/request/ProjectRelatedLinkData.kt
@@ -1,0 +1,10 @@
+package com.msg.sms.data.remote.dto.student.request
+
+import com.google.gson.annotations.SerializedName
+
+data class ProjectRelatedLinkData(
+    @SerializedName("name")
+    val name: String,
+    @SerializedName("url")
+    val url: String
+)

--- a/data/src/main/java/com/msg/sms/data/repository/StudentRepositoryImpl.kt
+++ b/data/src/main/java/com/msg/sms/data/repository/StudentRepositoryImpl.kt
@@ -1,7 +1,7 @@
 package com.msg.sms.data.repository
 
 import com.msg.sms.data.remote.datasource.student.RemoteStudentDataSource
-import com.msg.sms.data.remote.dto.student.request.CertificateInformation
+import com.msg.sms.data.remote.dto.student.request.CertificateData
 import com.msg.sms.data.remote.dto.student.request.EnterStudentInformationRequest
 import com.msg.sms.data.remote.dto.student.response.toGetStudentForAnonymous
 import com.msg.sms.data.remote.dto.student.response.toGetStudentForStudent
@@ -35,7 +35,7 @@ class StudentRepositoryImpl @Inject constructor(
                 salary = body.salary,
                 region = body.region,
                 languageCertificate = body.languageCertificate.map {
-                    CertificateInformation(
+                    CertificateData(
                         languageCertificateName = it.languageCertificateName,
                         score = it.score
                     )

--- a/data/src/main/java/com/msg/sms/data/repository/StudentRepositoryImpl.kt
+++ b/data/src/main/java/com/msg/sms/data/repository/StudentRepositoryImpl.kt
@@ -1,8 +1,7 @@
 package com.msg.sms.data.repository
 
 import com.msg.sms.data.remote.datasource.student.RemoteStudentDataSource
-import com.msg.sms.data.remote.dto.student.request.CertificateData
-import com.msg.sms.data.remote.dto.student.request.EnterStudentInformationRequest
+import com.msg.sms.data.remote.dto.student.request.*
 import com.msg.sms.data.remote.dto.student.response.toGetStudentForAnonymous
 import com.msg.sms.data.remote.dto.student.response.toGetStudentForStudent
 import com.msg.sms.data.remote.dto.student.response.toGetStudentForTeacher
@@ -41,7 +40,34 @@ class StudentRepositoryImpl @Inject constructor(
                     )
                 },
                 militaryService = body.militaryService,
-                certificate = body.certificate
+                certificate = body.certificate,
+                projects = body.projects.map { project ->
+                    ProjectData(
+                        name = project.name,
+                        icon = project.icon,
+                        previewImages = project.previewImages,
+                        description = project.description,
+                        links = project.links.map {
+                            ProjectRelatedLinkData(
+                                name = it.name,
+                                url = it.url
+                            )
+                        },
+                        techStacks = project.techStacks,
+                        myActivity = project.myActivity,
+                        inProgress = ProjectDateData(
+                            start = project.inProgress.start,
+                            end = project.inProgress.end
+                        )
+                    )
+                },
+                prize = body.prize.map {
+                    PrizeData(
+                        name = it.name,
+                        type = it.type,
+                        date = it.date
+                    )
+                }
             )
         )
     }

--- a/domain/src/main/java/com/msg/sms/domain/model/student/request/EnterStudentInformationModel.kt
+++ b/domain/src/main/java/com/msg/sms/domain/model/student/request/EnterStudentInformationModel.kt
@@ -13,5 +13,7 @@ data class EnterStudentInformationModel(
     val region: List<String>,
     val languageCertificate: List<CertificateInformationModel>,
     val militaryService: String,
-    val certificate: List<String>
+    val certificate: List<String>,
+    val projects: List<ProjectModel>,
+    val prize: List<PrizeModel>
 )

--- a/domain/src/main/java/com/msg/sms/domain/model/student/request/PrizeModel.kt
+++ b/domain/src/main/java/com/msg/sms/domain/model/student/request/PrizeModel.kt
@@ -1,0 +1,7 @@
+package com.msg.sms.domain.model.student.request
+
+data class PrizeModel(
+    val name: String,
+    val type: String,
+    val date: String
+)

--- a/domain/src/main/java/com/msg/sms/domain/model/student/request/ProjectDateModel.kt
+++ b/domain/src/main/java/com/msg/sms/domain/model/student/request/ProjectDateModel.kt
@@ -1,0 +1,6 @@
+package com.msg.sms.domain.model.student.request
+
+data class ProjectDateModel(
+    val start: String,
+    val end: String
+)

--- a/domain/src/main/java/com/msg/sms/domain/model/student/request/ProjectModel.kt
+++ b/domain/src/main/java/com/msg/sms/domain/model/student/request/ProjectModel.kt
@@ -1,0 +1,12 @@
+package com.msg.sms.domain.model.student.request
+
+data class ProjectModel(
+    val name: String,
+    val icon: String,
+    val previewImages: List<String>,
+    val description: String,
+    val links: List<ProjectRelatedLinkModel>,
+    val techStacks: List<String>,
+    val myActivity: String,
+    val inProgress: ProjectDateModel
+)

--- a/domain/src/main/java/com/msg/sms/domain/model/student/request/ProjectRelatedLinkModel.kt
+++ b/domain/src/main/java/com/msg/sms/domain/model/student/request/ProjectRelatedLinkModel.kt
@@ -1,0 +1,6 @@
+package com.msg.sms.domain.model.student.request
+
+data class ProjectRelatedLinkModel(
+    val name: String,
+    val url: String
+)

--- a/presentation/src/main/java/com/sms/presentation/main/viewmodel/FillOutViewModel.kt
+++ b/presentation/src/main/java/com/sms/presentation/main/viewmodel/FillOutViewModel.kt
@@ -9,6 +9,8 @@ import com.msg.sms.domain.model.fileupload.response.FileUploadResponseModel
 import com.msg.sms.domain.model.major.MajorListModel
 import com.msg.sms.domain.model.student.request.CertificateInformationModel
 import com.msg.sms.domain.model.student.request.EnterStudentInformationModel
+import com.msg.sms.domain.model.student.request.PrizeModel
+import com.msg.sms.domain.model.student.request.ProjectModel
 import com.msg.sms.domain.usecase.fileupload.ImageUploadUseCase
 import com.msg.sms.domain.usecase.major.GetMajorListUseCase
 import com.msg.sms.domain.usecase.student.EnterStudentInformationUseCase
@@ -171,6 +173,8 @@ class FillOutViewModel @Inject constructor(
         languageCertificate: List<CertificateInformationModel>,
         militaryService: String,
         certificate: List<String>,
+        projects: List<ProjectModel>,
+        prize: List<PrizeModel>
     ) = viewModelScope.launch {
         enterStudentInformationUseCase(
             EnterStudentInformationModel(
@@ -186,7 +190,9 @@ class FillOutViewModel @Inject constructor(
                 region = region,
                 languageCertificate = languageCertificate,
                 militaryService = militaryService,
-                certificate = certificate
+                certificate = certificate,
+                projects = projects,
+                prize = prize
             )
         ).onSuccess {
             it.catch { remoteError ->


### PR DESCRIPTION
## 💡 개요
- 정보기입에 프로젝트와 수상경력이 추가됨에 따라 관련 로직을 수정합니다.

## 📃 작업내용
- data와 domain레이어에 프로젝트와 수상경력에 관련된 DTO 추가

## 🔀 변경사항
- 정보기입 repository의 타입 변환 코드 수정
- 뷰모델 정보기입 함수에 파라미터 추가
