### PR TITLE
🔀 :: (#332) - 메인 페이지의 리스트가 나오지 않는 문제 해결

### DIFF
--- a/data/src/main/java/com/msg/sms/data/remote/dto/student/response/GetStudentListResponse.kt
+++ b/data/src/main/java/com/msg/sms/data/remote/dto/student/response/GetStudentListResponse.kt
@@ -1,12 +1,18 @@
 package com.msg.sms.data.remote.dto.student.response
 
+import com.google.gson.annotations.SerializedName
 import com.msg.sms.domain.model.student.response.StudentListModel
 
 data class GetStudentListResponse(
+    @SerializedName("content")
     val content: List<StudentInformation>,
+    @SerializedName("page")
     val page: Int,
+    @SerializedName("contentSize")
     val contentSize: Int,
+    @SerializedName("last")
     val last: Boolean,
+    @SerializedName("totalSize")
     val totalSize: Int
 )
 

--- a/data/src/main/java/com/msg/sms/data/remote/dto/student/response/StudentInformation.kt
+++ b/data/src/main/java/com/msg/sms/data/remote/dto/student/response/StudentInformation.kt
@@ -7,11 +7,11 @@ import java.util.UUID
 data class StudentInformation(
     @SerializedName("id")
     val id: UUID,
-    @SerializedName("major")
+    @SerializedName("profileImgUrl")
     val profileImg: String,
     @SerializedName("name")
     val name: String,
-    @SerializedName("profileImg")
+    @SerializedName("major")
     val major: String,
     @SerializedName("techStacks")
     val techStack: List<String>,

--- a/data/src/main/java/com/msg/sms/data/remote/dto/student/response/StudentInformation.kt
+++ b/data/src/main/java/com/msg/sms/data/remote/dto/student/response/StudentInformation.kt
@@ -1,13 +1,19 @@
 package com.msg.sms.data.remote.dto.student.response
 
+import com.google.gson.annotations.SerializedName
 import com.msg.sms.domain.model.student.response.StudentModel
 import java.util.UUID
 
 data class StudentInformation(
+    @SerializedName("id")
     val id: UUID,
+    @SerializedName("major")
     val profileImg: String,
+    @SerializedName("name")
     val name: String,
+    @SerializedName("profileImg")
     val major: String,
+    @SerializedName("techStacks")
     val techStack: List<String>,
 )
 


### PR DESCRIPTION
## 💡 개요
- 메인 페이지의 리스트가 나오지 않는 문제 해결

## 🔀 변경사항
- StudentList 요청의 Response DTO에 SerializedName을 붙여 서버와 변수 이름을 맞췄습니다.
