### PR TITLE
🔀 :: (#344) - 디테일 페이지 UI수정

### DIFF
--- a/presentation/src/main/java/com/sms/presentation/main/ui/detail/StudentDetailComponent.kt
+++ b/presentation/src/main/java/com/sms/presentation/main/ui/detail/StudentDetailComponent.kt
@@ -18,9 +18,11 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.msg.sms.design.component.button.SmsRoundedButton
 import com.msg.sms.domain.model.common.CertificateModel
+import com.sms.presentation.main.ui.detail.award.AwardComponent
 import com.sms.presentation.main.ui.detail.data.AwardData
 import com.sms.presentation.main.ui.detail.data.ProjectData
 import com.sms.presentation.main.ui.detail.data.RelatedLinksData
+import com.sms.presentation.main.ui.detail.info.StudentInfoComponent
 import com.sms.presentation.main.ui.detail.profile.StudentProfileComponent
 import com.sms.presentation.main.ui.detail.project.ProjectListComponent
 import com.sms.presentation.main.ui.fill_out_information.data.WorkConditionData

--- a/presentation/src/main/java/com/sms/presentation/main/ui/detail/StudentDetailComponent.kt
+++ b/presentation/src/main/java/com/sms/presentation/main/ui/detail/StudentDetailComponent.kt
@@ -5,29 +5,23 @@ import android.net.Uri
 import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
-import androidx.compose.foundation.lazy.LazyRow
-import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.msg.sms.design.component.button.SmsRoundedButton
-import com.msg.sms.design.component.item.TechStackItem
-import com.msg.sms.design.theme.SMSTheme
 import com.msg.sms.domain.model.common.CertificateModel
 import com.sms.presentation.main.ui.detail.data.AwardData
 import com.sms.presentation.main.ui.detail.data.ProjectData
 import com.sms.presentation.main.ui.detail.data.RelatedLinksData
+import com.sms.presentation.main.ui.detail.profile.StudentProfileComponent
 import com.sms.presentation.main.ui.detail.project.ProjectListComponent
 import com.sms.presentation.main.ui.fill_out_information.data.WorkConditionData
 import com.sms.presentation.main.ui.mypage.state.ActivityDuration
@@ -74,73 +68,26 @@ fun StudentDetailComponent(
         Box {
             Column(
                 modifier = Modifier
+                    .fillMaxWidth()
                     .clip(RoundedCornerShape(topEnd = 24.dp, topStart = 24.dp))
                     .background(Color.White)
+                    .padding(horizontal = 20.dp),
+                verticalArrangement = Arrangement.spacedBy(40.dp)
             ) {
-                val itemModifier = Modifier.padding(horizontal = 20.dp)
-
                 Spacer(modifier = Modifier.height(16.dp))
-
-                SMSTheme { colors, typography ->
-                    Text(
-                        text = major,
-                        style = typography.body1,
-                        color = colors.S2,
-                        fontWeight = FontWeight.Normal,
-                        modifier = itemModifier
-                    )
-                    Spacer(modifier = Modifier.height(4.dp))
-                    Text(
-                        text = name,
-                        style = typography.headline3,
-                        color = colors.BLACK,
-                        fontWeight = FontWeight.Bold,
-                        modifier = itemModifier
-                    )
-                    if (isNotGuest) {
-                        Spacer(modifier = Modifier.height(8.dp))
-                        Text(
-                            text = "${grade}학년 ${classNumber}반 ${schoolNumber}번 • $departments",
-                            style = typography.body2,
-                            color = colors.N40,
-                            modifier = itemModifier
-                        )
-                    }
-                    Spacer(modifier = Modifier.height(16.dp))
-                    LazyRow(
-                        verticalAlignment = Alignment.CenterVertically,
-                        horizontalArrangement = Arrangement.spacedBy(4.dp),
-                        modifier = itemModifier
-                    ) {
-                        items(techStack) {
-                            TechStackItem(techStack = it)
-                        }
-                    }
-                    Spacer(modifier = Modifier.height(16.dp))
-                    Column(
-                        modifier = itemModifier
-                            .fillMaxWidth()
-                            .clip(RoundedCornerShape(8.dp))
-                            .background(colors.N10)
-                    ) {
-                        Text(
-                            text = "자기소개",
-                            style = typography.caption2,
-                            color = colors.N40,
-                            modifier = Modifier.padding(start = 16.dp, end = 16.dp, top = 16.dp)
-                        )
-                        Spacer(modifier = Modifier.height(4.dp))
-                        Text(
-                            text = introduce,
-                            style = typography.body2,
-                            color = colors.BLACK,
-                            modifier = Modifier.padding(start = 16.dp, end = 16.dp, bottom = 16.dp)
-                        )
-                    }
-                }
+                StudentProfileComponent(
+                    major = major,
+                    name = name,
+                    isNotGuest = isNotGuest,
+                    techStack = techStack,
+                    grade = grade,
+                    classNumber = classNumber,
+                    schoolNumber = schoolNumber,
+                    departments = departments,
+                    introduce = introduce
+                )
                 if (isTeacher) {
                     StudentInfoComponent(
-                        modifier = itemModifier,
                         gsmAuthenticationScore = gsmAuthenticationScore,
                         email = email,
                         militaryService = militaryService,
@@ -156,7 +103,7 @@ fun StudentDetailComponent(
                 Column(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .padding(start = 20.dp, end = 20.dp, bottom = 20.dp, top = 40.dp)
+                        .padding(start = 20.dp, end = 20.dp, bottom = 20.dp)
                 ) {
                     if (awardData.isNotEmpty()) {
                         AwardComponent(awardList = awardData)

--- a/presentation/src/main/java/com/sms/presentation/main/ui/detail/StudentDetailComponent.kt
+++ b/presentation/src/main/java/com/sms/presentation/main/ui/detail/StudentDetailComponent.kt
@@ -103,7 +103,7 @@ fun StudentDetailComponent(
                 Column(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .padding(start = 20.dp, end = 20.dp, bottom = 20.dp)
+                        .padding(bottom = 20.dp)
                 ) {
                     if (awardData.isNotEmpty()) {
                         AwardComponent(awardList = awardData)

--- a/presentation/src/main/java/com/sms/presentation/main/ui/detail/StudentInfoComponent.kt
+++ b/presentation/src/main/java/com/sms/presentation/main/ui/detail/StudentInfoComponent.kt
@@ -1,12 +1,10 @@
 package com.sms.presentation.main.ui.detail
 
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.*
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.msg.sms.design.component.divider.SmsDivider
 import com.msg.sms.design.theme.SMSTheme
@@ -15,7 +13,7 @@ import com.sms.presentation.main.ui.fill_out_information.data.WorkConditionData
 
 @Composable
 fun StudentInfoComponent(
-    modifier: Modifier,
+    modifier: Modifier = Modifier,
     gsmAuthenticationScore: String,
     email: String,
     militaryService: String,
@@ -30,9 +28,7 @@ fun StudentInfoComponent(
         .fillMaxWidth(0.6f)
         .padding(8.dp)
 
-    Column(
-        modifier = modifier.fillMaxWidth()
-    ) {
+    Column(modifier = modifier.fillMaxWidth()) {
         SMSTheme { colors, typography ->
             val titleColor = colors.BLACK
             val contentColor = colors.N40
@@ -40,6 +36,13 @@ fun StudentInfoComponent(
             val titleTypography = typography.body1
             val contentTypography = typography.body2
 
+            Text(
+                text = "세부정보",
+                style = typography.title2,
+                color = colors.BLACK,
+                fontWeight = FontWeight.Bold
+            )
+            Spacer(modifier = Modifier.height(16.dp))
             Row(Modifier.fillMaxWidth()) {
                 Text(
                     text = "이메일",

--- a/presentation/src/main/java/com/sms/presentation/main/ui/detail/award/AwardComponent.kt
+++ b/presentation/src/main/java/com/sms/presentation/main/ui/detail/award/AwardComponent.kt
@@ -1,4 +1,4 @@
-package com.sms.presentation.main.ui.detail
+package com.sms.presentation.main.ui.detail.award
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement

--- a/presentation/src/main/java/com/sms/presentation/main/ui/detail/info/StudentInfoComponent.kt
+++ b/presentation/src/main/java/com/sms/presentation/main/ui/detail/info/StudentInfoComponent.kt
@@ -1,4 +1,4 @@
-package com.sms.presentation.main.ui.detail
+package com.sms.presentation.main.ui.detail.info
 
 import androidx.compose.foundation.layout.*
 import androidx.compose.material.Text

--- a/presentation/src/main/java/com/sms/presentation/main/ui/detail/profile/StudentProfileComponent.kt
+++ b/presentation/src/main/java/com/sms/presentation/main/ui/detail/profile/StudentProfileComponent.kt
@@ -1,0 +1,89 @@
+package com.sms.presentation.main.ui.detail.profile
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.msg.sms.design.component.item.TechStackItem
+import com.msg.sms.design.theme.SMSTheme
+
+@Composable
+fun StudentProfileComponent(
+    major: String,
+    name: String,
+    isNotGuest: Boolean,
+    techStack: List<String>,
+    grade: String,
+    classNumber: String,
+    schoolNumber: String,
+    departments: String,
+    introduce: String
+) {
+    SMSTheme { colors, typography ->
+        Column(modifier = Modifier.fillMaxWidth()) {
+            Text(
+                text = major,
+                style = typography.body1,
+                color = colors.S2,
+                fontWeight = FontWeight.Normal,
+                modifier = Modifier.fillMaxWidth()
+            )
+            Spacer(modifier = Modifier.height(4.dp))
+            Text(
+                text = name,
+                style = typography.headline3,
+                color = colors.BLACK,
+                fontWeight = FontWeight.Bold,
+                modifier = Modifier.fillMaxWidth()
+            )
+            if (isNotGuest) {
+                Spacer(modifier = Modifier.height(8.dp))
+                Text(
+                    text = "${grade}학년 ${classNumber}반 ${schoolNumber}번 • $departments",
+                    style = typography.body2,
+                    color = colors.N40,
+                    modifier = Modifier.fillMaxWidth()
+                )
+            }
+            Spacer(modifier = Modifier.height(16.dp))
+            LazyRow(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(4.dp),
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                items(techStack) {
+                    TechStackItem(techStack = it)
+                }
+            }
+            Spacer(modifier = Modifier.height(16.dp))
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clip(RoundedCornerShape(8.dp))
+                    .background(colors.N10)
+            ) {
+                Text(
+                    text = "자기소개",
+                    style = typography.caption2,
+                    color = colors.N40,
+                    modifier = Modifier.padding(start = 16.dp, end = 16.dp, top = 16.dp)
+                )
+                Spacer(modifier = Modifier.height(4.dp))
+                Text(
+                    text = introduce,
+                    style = typography.body2,
+                    color = colors.BLACK,
+                    modifier = Modifier.padding(start = 16.dp, end = 16.dp, bottom = 16.dp)
+                )
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 💡 개요
- 디테일 페이지 UI를 수정합니다.
## 📃 작업내용
- 디테일 학생 정보에 없던 헤더를 추가했습니다.
- 섹션별로 컴포넌트를 분리하고 패키징을 진행했습니다.

![스크린샷 2023-08-31 오후 4 01 50](https://github.com/GSM-MSG/SMS-Android/assets/80810303/80a201bc-c0fb-4e17-912b-d50c5fe385a3)

