### PR TITLE
🔀 :: (#355) - 이미지 extension이 맞아야만 이미지 업로드 될 수 있도록 변경

### DIFF
--- a/presentation/src/main/java/com/sms/presentation/main/ui/fill_out_information/FillOutInformationActivity.kt
+++ b/presentation/src/main/java/com/sms/presentation/main/ui/fill_out_information/FillOutInformationActivity.kt
@@ -2,7 +2,6 @@ package com.sms.presentation.main.ui.fill_out_information
 
 import android.content.Intent
 import android.net.Uri
-import android.util.Log
 import androidx.activity.compose.setContent
 import androidx.activity.viewModels
 import androidx.compose.foundation.background
@@ -243,9 +242,11 @@ class FillOutInformationActivity : BaseActivity() {
                         BottomSheetValues.PhotoPicker -> {
                             PhotoPickBottomSheet(
                                 bottomSheetState = bottomSheetState,
-                                onProfileImageUriChanged = { uri, extension ->
-                                    isImageExtensionInCorrect.value = extension
-                                    profileImageUri.value = if (extension) Uri.EMPTY else uri
+                                onProfileImageUriChanged = { uri, isImageExtensionCorrect ->
+                                    isImageExtensionInCorrect.value = !isImageExtensionCorrect
+                                    if (isImageExtensionCorrect) {
+                                        profileImageUri.value = uri
+                                    }
                                 }
                             )
                         }

--- a/presentation/src/main/java/com/sms/presentation/main/ui/fill_out_information/component/bottomsheet/PhotoPickBottomSheet.kt
+++ b/presentation/src/main/java/com/sms/presentation/main/ui/fill_out_information/component/bottomsheet/PhotoPickBottomSheet.kt
@@ -20,7 +20,7 @@ import com.sms.presentation.main.ui.util.toUri
 @Composable
 fun PhotoPickBottomSheet(
     bottomSheetState: ModalBottomSheetState,
-    onProfileImageUriChanged: (uri: Uri, extention: Boolean) -> Unit
+    onProfileImageUriChanged: (uri: Uri, isImageExtensionCorrect: Boolean) -> Unit
 ) {
     val context = LocalContext.current
     val isCamera = remember {
@@ -31,7 +31,7 @@ fun PhotoPickBottomSheet(
             if (uri != null) {
                 onProfileImageUriChanged(
                     uri,
-                    !getFileNameFromUri(context, uri)!!.isImageExtensionCorrect()
+                    getFileNameFromUri(context, uri)!!.isImageExtensionCorrect()
                 )
             }
         }


### PR DESCRIPTION
## 💡 개요
- 이미지 extension이 맞아야만 이미지 업로드 될 수 있도록 변경

## 🔀 변경사항
- 기존의 이미지 extension이 맞으면 넘어온 uri를 넘기고 그렇지 않다면 Uri.EMPTY를 넘기던 방식에서 extension이 맞아야만 이미지 uri를 넘기도록 수정하였습니다.

## 🖥️ 주요코드
```kotlin
PhotoPickBottomSheet(
    bottomSheetState = bottomSheetState,
    onProfileImageUriChanged = { uri, isImageExtensionCorrect ->
        isImageExtensionInCorrect.value = !isImageExtensionCorrect
        if (isImageExtensionCorrect) {
            profileImageUri.value = uri
        }
    }
)
```
