### PR TITLE
🔀 :: (#358) - 프로필 세부스택 삭제 기능 구현

### DIFF
--- a/presentation/src/main/java/com/sms/presentation/main/ui/fill_out_information/FillOutInformationActivity.kt
+++ b/presentation/src/main/java/com/sms/presentation/main/ui/fill_out_information/FillOutInformationActivity.kt
@@ -391,8 +391,9 @@ class FillOutInformationActivity : BaseActivity() {
                                                 snackBarVisible.value = false
                                             }
                                         },
-                                        onProjectValueChanged = {
+                                        onProfileValueChanged = {
                                             profileData.value = it
+                                            Log.d("profileData", it.toString())
                                         }
                                     )
                                 }

--- a/presentation/src/main/java/com/sms/presentation/main/ui/fill_out_information/FillOutInformationActivity.kt
+++ b/presentation/src/main/java/com/sms/presentation/main/ui/fill_out_information/FillOutInformationActivity.kt
@@ -395,7 +395,6 @@ class FillOutInformationActivity : BaseActivity() {
                                         },
                                         onTechStackItemRemoved = {
                                             profileDetailTechStack.remove(it)
-                                            profileData.value = profileData.value.copy(techStack = profileDetailTechStack)
                                         }
                                     )
                                 }

--- a/presentation/src/main/java/com/sms/presentation/main/ui/fill_out_information/FillOutInformationActivity.kt
+++ b/presentation/src/main/java/com/sms/presentation/main/ui/fill_out_information/FillOutInformationActivity.kt
@@ -2,7 +2,6 @@ package com.sms.presentation.main.ui.fill_out_information
 
 import android.content.Intent
 import android.net.Uri
-import android.util.Log
 import androidx.activity.compose.setContent
 import androidx.activity.viewModels
 import androidx.compose.foundation.background
@@ -393,7 +392,10 @@ class FillOutInformationActivity : BaseActivity() {
                                         },
                                         onProfileValueChanged = {
                                             profileData.value = it
-                                            Log.d("profileData", it.toString())
+                                        },
+                                        onTechStackItemRemoved = {
+                                            profileDetailTechStack.remove(it)
+                                            profileData.value = profileData.value.copy(techStack = profileDetailTechStack)
                                         }
                                     )
                                 }

--- a/presentation/src/main/java/com/sms/presentation/main/ui/fill_out_information/component/profile/ProfileComponent.kt
+++ b/presentation/src/main/java/com/sms/presentation/main/ui/fill_out_information/component/profile/ProfileComponent.kt
@@ -39,7 +39,8 @@ fun ProfileComponent(
     onMajorBottomSheetOpenButtonClick: () -> Unit,
     onPhotoPickBottomSheetOpenButtonClick: () -> Unit,
     isRequired: (Boolean) -> Unit,
-    onProfileValueChanged: (data: ProfileData) -> Unit
+    onProfileValueChanged: (data: ProfileData) -> Unit,
+    onTechStackItemRemoved: (item: String) -> Unit
 ) {
     SMSTheme { _, typography ->
         val context = LocalContext.current as FillOutInformationActivity
@@ -136,10 +137,10 @@ fun ProfileComponent(
             )
             Spacer(modifier = Modifier.height(24.dp))
             ProfileTechStackInputComponent(
-                selectedTechStack = detailStacks,
+                techStack = detailStacks,
                 onClick = changeView,
-                onProfileTechStackValueChanged = { techStacks ->
-                    onProfileValueChanged(data.copy(techStack = techStacks))
+                onTechStackRemoved = { removedItem ->
+                    onTechStackItemRemoved(removedItem)
                 }
             )
         }
@@ -160,6 +161,7 @@ fun ProfileComponentPre() {
         enteredMajor = "",
         onMajorBottomSheetOpenButtonClick = {},
         onPhotoPickBottomSheetOpenButtonClick = {},
-        onProfileValueChanged = {}
+        onProfileValueChanged = {},
+        onTechStackItemRemoved = {}
     )
 }

--- a/presentation/src/main/java/com/sms/presentation/main/ui/fill_out_information/component/profile/ProfileComponent.kt
+++ b/presentation/src/main/java/com/sms/presentation/main/ui/fill_out_information/component/profile/ProfileComponent.kt
@@ -136,7 +136,7 @@ fun ProfileComponent(
             )
             Spacer(modifier = Modifier.height(24.dp))
             ProfileTechStackInputComponent(
-                techStack = detailStacks,
+                selectedTechStack = detailStacks,
                 onClick = changeView,
                 onProfileTechStackValueChanged = { techStacks ->
                     onProfileValueChanged(data.copy(techStack = techStacks))

--- a/presentation/src/main/java/com/sms/presentation/main/ui/fill_out_information/component/profile/ProfileComponent.kt
+++ b/presentation/src/main/java/com/sms/presentation/main/ui/fill_out_information/component/profile/ProfileComponent.kt
@@ -141,6 +141,7 @@ fun ProfileComponent(
                 onClick = changeView,
                 onTechStackRemoved = { removedItem ->
                     onTechStackItemRemoved(removedItem)
+                    onProfileValueChanged(data.copy(techStack = detailStacks.minus(removedItem)))
                 }
             )
         }

--- a/presentation/src/main/java/com/sms/presentation/main/ui/fill_out_information/component/profile/ProfileTechStackInputComponent.kt
+++ b/presentation/src/main/java/com/sms/presentation/main/ui/fill_out_information/component/profile/ProfileTechStackInputComponent.kt
@@ -21,7 +21,7 @@ import com.sms.presentation.main.ui.mypage.component.profile.DisplaySearchBar
 fun ProfileTechStackInputComponent(
     techStack: List<String>,
     onClick: () -> Unit,
-    onProfileTechStackValueChanged: (value: List<String>) -> Unit
+    onTechStackRemoved: (item: String) -> Unit
 ) {
     AddGrayBody1Title(titleText = "사용기술 (최대 5개)") {
         Column(
@@ -60,9 +60,7 @@ fun ProfileTechStackInputComponent(
                 itemsIndexed(techStack) { _: Int, item: String ->
                     DetailTechStackItem(
                         stack = item,
-                        onClick = {
-                            onProfileTechStackValueChanged(techStack.minus(item))
-                        }
+                        onClick = { onTechStackRemoved(item) }
                     )
                 }
             }

--- a/presentation/src/main/java/com/sms/presentation/main/ui/fill_out_information/screen/ProfileScreen.kt
+++ b/presentation/src/main/java/com/sms/presentation/main/ui/fill_out_information/screen/ProfileScreen.kt
@@ -33,7 +33,8 @@ fun ProfileScreen(
     onMajorBottomSheetOpenButtonClick: () -> Unit,
     onDialogDissmissButtonClick: () -> Unit,
     onSnackBarVisibleChanged: (text: String) -> Unit,
-    onProjectValueChanged: (data: ProfileData) -> Unit
+    onProfileValueChanged: (data: ProfileData) -> Unit,
+    onTechStackItemRemoved: (item: String) -> Unit
 ) {
     val scrollState = rememberScrollState()
     val isRequired = remember {
@@ -98,7 +99,8 @@ fun ProfileScreen(
                 onPhotoPickBottomSheetOpenButtonClick = onPhotoPickBottomSheetOpenButtonClick,
                 onMajorBottomSheetOpenButtonClick = onMajorBottomSheetOpenButtonClick,
                 isRequired = { result -> isRequired.value = result },
-                onProfileValueChanged = onProjectValueChanged
+                onProfileValueChanged = onProfileValueChanged,
+                onTechStackItemRemoved = onTechStackItemRemoved
             )
             Column(modifier = Modifier.padding(horizontal = 20.dp)) {
                 Spacer(modifier = Modifier.height(32.dp))


### PR DESCRIPTION
## 💡 개요
- 프로필 세부스택 삭제 기능 구현

## 🔀 변경사항
- 프로필 테크스택은 profileDetailTechStack이라는 변수를 참조하고 있지만 실제로는 ProfileData만 copy를 통해 지워주기 때문에 UI상에서 지워지지 않던 문제를 profileDetailTechStack도 삭제 버튼 클릭시 함께 값을 없애주도록 변경하여 문제를 해결함

## 🖥️ 주요코드
```kotlin
onTechStackRemoved = { removedItem ->
    onTechStackItemRemoved(removedItem)
    onProfileValueChanged(data.copy(techStack = detailStacks.minus(removedItem)))
}
```
