### PR TITLE
🔀 :: (#362) - 인증제 점수 인풋 이슈 해결

### DIFF
--- a/presentation/src/main/java/com/sms/presentation/main/ui/fill_out_information/component/schoollife/SchoolLifeComponent.kt
+++ b/presentation/src/main/java/com/sms/presentation/main/ui/fill_out_information/component/schoollife/SchoolLifeComponent.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.unit.dp
 import com.msg.sms.design.component.text.SmsTitleText
 import com.msg.sms.design.component.textfield.SmsTextField
 import com.msg.sms.design.theme.SMSTheme
+import com.sms.presentation.main.ui.util.returnNumberOnly
 
 
 @Composable
@@ -33,8 +34,11 @@ fun SchoolLifeComponent(
                     imeAction = ImeAction.Done
                 ),
                 onValueChange = {
-                    gsmAuthenticationScore(it.replace(".",""))
-                }) {
+                    it.returnNumberOnly { number ->
+                        gsmAuthenticationScore(number.toString())
+                    }
+                }
+            ) {
                 gsmAuthenticationScore("")
             }
         }

--- a/presentation/src/main/java/com/sms/presentation/main/ui/fill_out_information/component/schoollife/SchoolLifeComponent.kt
+++ b/presentation/src/main/java/com/sms/presentation/main/ui/fill_out_information/component/schoollife/SchoolLifeComponent.kt
@@ -11,7 +11,6 @@ import androidx.compose.ui.unit.dp
 import com.msg.sms.design.component.text.SmsTitleText
 import com.msg.sms.design.component.textfield.SmsTextField
 import com.msg.sms.design.theme.SMSTheme
-import com.sms.presentation.main.ui.util.returnNumberOnly
 
 
 @Composable
@@ -30,13 +29,11 @@ fun SchoolLifeComponent(
                 modifier = Modifier.fillMaxWidth(),
                 setText = enteredGsmAuthenticationScore,
                 keyboardOptions = KeyboardOptions(
-                    keyboardType = KeyboardType.Number,
+                    keyboardType = KeyboardType.NumberPassword,
                     imeAction = ImeAction.Done
                 ),
                 onValueChange = {
-                    it.returnNumberOnly { number ->
-                        gsmAuthenticationScore(number.toString())
-                    }
+                    gsmAuthenticationScore(it)
                 }
             ) {
                 gsmAuthenticationScore("")

--- a/presentation/src/main/java/com/sms/presentation/main/ui/fill_out_information/component/schoollife/SchoolLifeComponent.kt
+++ b/presentation/src/main/java/com/sms/presentation/main/ui/fill_out_information/component/schoollife/SchoolLifeComponent.kt
@@ -33,7 +33,7 @@ fun SchoolLifeComponent(
                     imeAction = ImeAction.Done
                 ),
                 onValueChange = {
-                    gsmAuthenticationScore(it)
+                    gsmAuthenticationScore(it.replace(".",""))
                 }) {
                 gsmAuthenticationScore("")
             }

--- a/presentation/src/main/java/com/sms/presentation/main/ui/util/extension.kt
+++ b/presentation/src/main/java/com/sms/presentation/main/ui/util/extension.kt
@@ -117,11 +117,3 @@ fun String.isUrlRegularExpression(): Boolean {
     val urlRegex = Regex("^(http(s)?://)?[\\w.-]+\\.[a-zA-Z]{2,3}(/\\S*)?\$")
     return matches(urlRegex)
 }
-
-fun String.returnNumberOnly(number: (Int) -> Unit) {
-    runCatching {
-        this.toInt()
-    }.onSuccess {
-        number(it)
-    }
-}

--- a/presentation/src/main/java/com/sms/presentation/main/ui/util/extension.kt
+++ b/presentation/src/main/java/com/sms/presentation/main/ui/util/extension.kt
@@ -117,3 +117,11 @@ fun String.isUrlRegularExpression(): Boolean {
     val urlRegex = Regex("^(http(s)?://)?[\\w.-]+\\.[a-zA-Z]{2,3}(/\\S*)?\$")
     return matches(urlRegex)
 }
+
+fun String.returnNumberOnly(number: (Int) -> Unit) {
+    runCatching {
+        this.toInt()
+    }.onSuccess {
+        number(it)
+    }
+}


### PR DESCRIPTION
## 💡 개요
- 인증제 점수의 " . " 과 " - "이 입력되던 문제를 해결합니다.

## 📃 작업내용
- 호이스팅으로 값을 넘겨줄때 replace를 통해 " . "을 공백으로 치환해주어 " . " 과 " - "모두 입력이 불가능하도록 작업하였습니다.

##  🖥️ 주요코드
```kotlin
gsmAuthenticationScore(it.replace(".",""))
```
