### PR TITLE
🔀 :: (#367) - 희망 고용형태 바텀시트 직접입력 포함되어있는 문제 해결

### DIFF
--- a/presentation/src/main/java/com/sms/presentation/main/ui/fill_out_information/FillOutInformationActivity.kt
+++ b/presentation/src/main/java/com/sms/presentation/main/ui/fill_out_information/FillOutInformationActivity.kt
@@ -35,6 +35,7 @@ import com.msg.sms.domain.model.student.request.*
 import com.sms.presentation.main.ui.base.BaseActivity
 import com.sms.presentation.main.ui.detail_stack_search.DetailStackSearchScreen
 import com.sms.presentation.main.ui.fill_out_information.component.FillOutInformationTopBarComponent
+import com.sms.presentation.main.ui.fill_out_information.component.bottomsheet.HopeWorkConditionBottomSheet
 import com.sms.presentation.main.ui.fill_out_information.component.bottomsheet.MajorSelectorBottomSheet
 import com.sms.presentation.main.ui.fill_out_information.component.bottomsheet.MilitarySelectorBottomSheet
 import com.sms.presentation.main.ui.fill_out_information.component.bottomsheet.PhotoPickBottomSheet
@@ -261,7 +262,7 @@ class FillOutInformationActivity : BaseActivity() {
                             )
                         }
                         BottomSheetValues.WorkingForm -> {
-                            MajorSelectorBottomSheet(
+                            HopeWorkConditionBottomSheet(
                                 bottomSheetState = bottomSheetState,
                                 majorList = listOf("정규직", "비정규직", "계약직", "인턴"),
                                 selectedMajor = if (selectedWorkingCondition.value == "") enteredWorkConditionData.formOfEmployment else selectedWorkingCondition.value,

--- a/presentation/src/main/java/com/sms/presentation/main/ui/fill_out_information/component/bottomsheet/HopeWorkConditionBottomSheet.kt
+++ b/presentation/src/main/java/com/sms/presentation/main/ui/fill_out_information/component/bottomsheet/HopeWorkConditionBottomSheet.kt
@@ -1,0 +1,22 @@
+package com.sms.presentation.main.ui.fill_out_information.component.bottomsheet
+
+import androidx.compose.material.ExperimentalMaterialApi
+import androidx.compose.material.ModalBottomSheetState
+import androidx.compose.runtime.Composable
+import com.msg.sms.design.component.bottomsheet.SelectorBottomSheet
+
+@OptIn(ExperimentalMaterialApi::class)
+@Composable
+fun HopeWorkConditionBottomSheet(
+    bottomSheetState: ModalBottomSheetState,
+    selectedMajor: String,
+    majorList: List<String>,
+    onSelectedMajhorChange: (value: String) -> Unit,
+) {
+    SelectorBottomSheet(
+        list = majorList,
+        bottomSheetState = bottomSheetState,
+        selected = selectedMajor,
+        itemChange = onSelectedMajhorChange
+    )
+}


### PR DESCRIPTION
## 💡 개요
- 희망 고용 형태 바텀시트의 아이템에 직접입력이란 아이템이 포함되어있는 문제를 해결합니다.

## 🔀 변경사항
- 기존의 희망 고용형태 바텀시트가 Major 바텀시트로 구현되어있어 직접입력이 포함되는 문제를 희망 고용형태 바텀시트를 따로 제작해 해결하였습니다.

## 🖥️ 주요 코드
```kotlin
@OptIn(ExperimentalMaterialApi::class)
@Composable
fun HopeWorkConditionBottomSheet(
    bottomSheetState: ModalBottomSheetState,
    selectedMajor: String,
    majorList: List<String>,
    onSelectedMajhorChange: (value: String) -> Unit,
) {
    SelectorBottomSheet(
        list = majorList,
        bottomSheetState = bottomSheetState,
        selected = selectedMajor,
        itemChange = onSelectedMajhorChange
    )
}
```
