### PR TITLE
🔀 :: (#378) - 이미지 확장자 검사 boolean값 반대로 넘어오던 문제 해결

### DIFF
--- a/presentation/src/main/java/com/sms/presentation/main/ui/fill_out_information/component/bottomsheet/PhotoPickBottomSheet.kt
+++ b/presentation/src/main/java/com/sms/presentation/main/ui/fill_out_information/component/bottomsheet/PhotoPickBottomSheet.kt
@@ -41,7 +41,7 @@ fun PhotoPickBottomSheet(
             if (uri != null) {
                 onProfileImageUriChanged(
                     uri,
-                    !getFileNameFromUri(context, uri)!!.isImageExtensionCorrect()
+                    getFileNameFromUri(context, uri)!!.isImageExtensionCorrect()
                 )
             }
         }


### PR DESCRIPTION
## 💡 개요
- 이미지 확장자 검사 boolean값 반대로 넘어오던 문제 해결

## 📃 작업내용
- 카메라 런쳐에서 boolean값을 넘겨주는 로직에 " ! "를 삭제합니다.