### PR TITLE
🔀 :: (#388) - 메인페이지 리스트 페이지네이션 이슈 해결

### DIFF
--- a/presentation/src/main/java/com/sms/presentation/main/ui/main/MainActivity.kt
+++ b/presentation/src/main/java/com/sms/presentation/main/ui/main/MainActivity.kt
@@ -55,6 +55,7 @@ class MainActivity : BaseActivity() {
         observeEvent()
         authViewModel.getRoleInfo()
         fillOutViewModel.getMajorList()
+        studentListViewModel.getStudentListRequest(1, 20)
     }
 
     private fun observeEvent() {
@@ -147,6 +148,8 @@ class MainActivity : BaseActivity() {
                                         studentListViewModel.setFilterGsmScoreAscendingValue(studentListViewModel.selectedGsmScoreAscendingOrder.value)
                                         studentListViewModel.setFilterDesiredAnnualSalaryAscendingValue(studentListViewModel.selectedDesiredAnnualSalaryAscendingOrder.value)
                                         studentListViewModel.setFilterDetailStackList(studentListViewModel.selectedDetailStack)
+                                        studentListViewModel.clearStudentList()
+                                        studentListViewModel.getStudentListRequest(1, 20)
 
                                         navController.navigate(MainPage.Main.value)
                                     },

--- a/presentation/src/main/java/com/sms/presentation/main/ui/main/screen/MainScreen.kt
+++ b/presentation/src/main/java/com/sms/presentation/main/ui/main/screen/MainScreen.kt
@@ -417,7 +417,7 @@ suspend fun getStudentList(
         when (response) {
             is Event.Success -> {
                 progressState(false)
-                onSuccess(response.data!!.content, response.data.contentSize)
+                onSuccess(response.data!!.content, response.data.totalSize)
             }
 
             is Event.Loading -> {

--- a/presentation/src/main/java/com/sms/presentation/main/ui/main/screen/MainScreen.kt
+++ b/presentation/src/main/java/com/sms/presentation/main/ui/main/screen/MainScreen.kt
@@ -46,9 +46,6 @@ fun MainScreen(
 ) {
     val listState = rememberLazyListState()
     val scope = rememberCoroutineScope()
-    val studentList = remember {
-        mutableStateOf(listOf<StudentModel>())
-    }
     val progressState = remember {
         mutableStateOf(false)
     }
@@ -88,8 +85,6 @@ fun MainScreen(
         }
     }
 
-    viewModel.getStudentListRequest(1, 20)
-
     BackHandler {
         if (bottomSheetState.isVisible) {
             scope.launch {
@@ -117,7 +112,7 @@ fun MainScreen(
             viewModel = viewModel,
             progressState = { progressState.value = it },
             onSuccess = { list, size ->
-                studentList.value = list
+                viewModel.addStudentList(list)
                 listTotalSize.value = size
             }
         )
@@ -142,8 +137,8 @@ fun MainScreen(
     }
 
     LaunchedEffect(lastVisibleItem.value) {
-        if (lastVisibleItem.value == studentList.value.lastIndex) {
-
+        if (lastVisibleItem.value == viewModel.studentList.lastIndex && viewModel.getStudentListResponse.value.data?.last != true) {
+            viewModel.getStudentListRequest(viewModel.getStudentListResponse.value.data!!.page + 1, 20)
         }
     }
 
@@ -212,7 +207,7 @@ fun MainScreen(
                     StudentListComponent(
                         listState = listState,
                         progressState = progressState.value,
-                        studentList = studentList.value,
+                        studentList = viewModel.studentList,
                         listTotalSize = listTotalSize.value
                     ) {
                         lifecycleScope.launch {

--- a/presentation/src/main/java/com/sms/presentation/main/viewmodel/StudentListViewModel.kt
+++ b/presentation/src/main/java/com/sms/presentation/main/viewmodel/StudentListViewModel.kt
@@ -4,10 +4,7 @@ import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.msg.sms.domain.model.student.response.GetStudentForAnonymousModel
-import com.msg.sms.domain.model.student.response.GetStudentForStudentModel
-import com.msg.sms.domain.model.student.response.GetStudentForTeacherModel
-import com.msg.sms.domain.model.student.response.StudentListModel
+import com.msg.sms.domain.model.student.response.*
 import com.msg.sms.domain.model.user.response.ProfileImageModel
 import com.msg.sms.domain.usecase.auth.DeleteTokenUseCase
 import com.msg.sms.domain.usecase.auth.LogoutUseCase
@@ -70,6 +67,10 @@ class StudentListViewModel @Inject constructor(
     private val _getStudentProfileImageResponse =
         MutableStateFlow<Event<ProfileImageModel>>(Event.Loading)
     val getStudentProfileImageResponse = _getStudentProfileImageResponse.asStateFlow()
+
+    // Main List
+    var studentList = mutableStateListOf<StudentModel>()
+        private set
 
     //Filter - Selector
     var majorList = listOf<String>()
@@ -255,6 +256,14 @@ class StudentListViewModel @Inject constructor(
         }
     }
 
+    fun addStudentList(list: List<StudentModel>) {
+        studentList.addAll(list)
+    }
+
+    fun clearStudentList() {
+        studentList.clear()
+    }
+
     //Filter - Selector Setter (start)
     fun setFilterGradeList(gradeList: List<FilterGrade>) {
         filterGradeList.removeAll(filterGradeList.filter {
@@ -337,7 +346,7 @@ class StudentListViewModel @Inject constructor(
         })
     }
 
-    fun setSelectedTypeOfEmploymentList(typeOfEmploymentList: List<FilterTypeOfEmployment  >) {
+    fun setSelectedTypeOfEmploymentList(typeOfEmploymentList: List<FilterTypeOfEmployment>) {
         selectedTypeOfEmploymentList.removeAll(selectedTypeOfEmploymentList.filter {
             !typeOfEmploymentList.contains(it)
         })
@@ -410,9 +419,4 @@ class StudentListViewModel @Inject constructor(
         })
     }
     //Filter - DetailStack Setter (end)
-
-    fun resetFilterData() {
-
-    }
-
 }


### PR DESCRIPTION
## 💡 개요
- 메인페이지 리스트 페이지네이션 이슈 해결

## 📃 작업내용
- 학생 리스트를 뷰모델에서 관리하도록 변경
- 초기에는 액티비티에서 한번 리스트를 요청하고 이후에는 페이지네이션 로직에 따라 요청하도록 변경
- 필터페이지에서 필터링 정보 선택 후 확인 버튼을 누르면 전체 리스트를 지우고 다시 요청함
