### PR TITLE
🔀 :: (#409) - Exceptions when a web browser does not exist in an overseas device

### DIFF
--- a/presentation/src/main/AndroidManifest.xml
+++ b/presentation/src/main/AndroidManifest.xml
@@ -1,10 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"
         android:maxSdkVersion="32" />
     <uses-permission android:name="android.permission.CAMERA" />
+    <uses-permission android:name="android.permission.QUERY_ALL_PACKAGES"
+        tools:ignore="QueryAllPackagesPermission" />
 
     <application>
         <activity

--- a/presentation/src/main/java/com/sms/presentation/main/ui/login/component/LoginScreen.kt
+++ b/presentation/src/main/java/com/sms/presentation/main/ui/login/component/LoginScreen.kt
@@ -12,7 +12,10 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.msg.gauthsignin.GAuthSigninWebView
+import com.msg.sms.design.component.SmsDialog
 import com.sms.presentation.BuildConfig
+import com.sms.presentation.R
+import com.sms.presentation.main.ui.util.isBrowserInstalled
 
 @Composable
 fun LoginScreen(
@@ -24,6 +27,23 @@ fun LoginScreen(
         mutableStateOf(false)
     }
 
+    val dialogState = remember {
+        mutableStateOf(false)
+    }
+
+    if (dialogState.value) {
+        SmsDialog(
+            widthPercent = 1f,
+            heightPercent = 0.54f,
+            title = context.getString(R.string.browser_error_title),
+            msg = context.getString(R.string.browser_error_content),
+            outLineButtonText = context.getString(R.string.cansel),
+            importantButtonText = context.getString(R.string.check),
+            outlineButtonOnClick = { dialogState.value = false },
+            importantButtonOnClick = { dialogState.value = false }
+        )
+    }
+
     Box {
         LoginPageBackGround()
         TopComponent(context)
@@ -33,7 +53,12 @@ fun LoginScreen(
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
             LoginButton {
-                webViewVisible.value = true
+                if (isBrowserInstalled(context)) {
+                    webViewVisible.value = true
+                }
+                else {
+                    dialogState.value = true
+                }
             }
             Spacer(modifier = Modifier.height(16.dp))
             Row {

--- a/presentation/src/main/java/com/sms/presentation/main/ui/util/isBrowserInstalled.kt
+++ b/presentation/src/main/java/com/sms/presentation/main/ui/util/isBrowserInstalled.kt
@@ -10,17 +10,17 @@ fun isBrowserInstalled(context: Context): Boolean {
     val packageManager: PackageManager = context.packageManager
     val intent = Intent(Intent.ACTION_VIEW, Uri.parse("https://gauth.co.kr/"))
 
-    return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-        val list = packageManager.queryIntentActivities(
+    val list = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+        packageManager.queryIntentActivities(
             intent,
             PackageManager.ResolveInfoFlags.of(PackageManager.MATCH_DEFAULT_ONLY.toLong())
         )
-        list.isNotEmpty()
     } else {
-        val list = packageManager.queryIntentActivities(
+        packageManager.queryIntentActivities(
             intent,
             PackageManager.MATCH_DEFAULT_ONLY
         )
-        list.isNotEmpty()
     }
+
+    return list.isNotEmpty()
 }

--- a/presentation/src/main/java/com/sms/presentation/main/ui/util/isBrowserInstalled.kt
+++ b/presentation/src/main/java/com/sms/presentation/main/ui/util/isBrowserInstalled.kt
@@ -1,0 +1,26 @@
+package com.sms.presentation.main.ui.util
+
+import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.net.Uri
+import android.os.Build
+
+fun isBrowserInstalled(context: Context): Boolean {
+    val packageManager: PackageManager = context.packageManager
+    val intent = Intent(Intent.ACTION_VIEW, Uri.parse("https://gauth.co.kr/"))
+
+    return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+        val list = packageManager.queryIntentActivities(
+            intent,
+            PackageManager.ResolveInfoFlags.of(PackageManager.MATCH_DEFAULT_ONLY.toLong())
+        )
+        list.isNotEmpty()
+    } else {
+        val list = packageManager.queryIntentActivities(
+            intent,
+            PackageManager.MATCH_DEFAULT_ONLY
+        )
+        list.isNotEmpty()
+    }
+}

--- a/presentation/src/main/res/values-ko/strings.xml
+++ b/presentation/src/main/res/values-ko/strings.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="title_activity_main">MainActivity</string>
+    <string name="browser_error_title">브라우저 오류</string>
+    <string name="browser_error_content">브라우저를 찾을 수 없습니다.\n브라우저 설치 후 접속해 주세요.</string>
+    <string name="cansel">취소</string>
+    <string name="check">확인</string>
+</resources>

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -1,7 +1,11 @@
 <resources>
     <string name="title_activity_main">MainActivity</string>
-    <string name="title_activity_login">LoginActivity</string>
-    <string name="login_page_topcomponent_text_english">STUDENT\nMANAGEMENT\nSERVICE</string>
-    <string name="login_page_topcomponent_text_korean">학생 정보 통합관리 서비스</string>
-    <string name="title_activity_fill_out_information">FillOutInformationActivity</string>
+    <string name="title_activity_login" translatable="false">LoginActivity</string>
+    <string name="login_page_topcomponent_text_english" translatable="false">STUDENT\nMANAGEMENT\nSERVICE</string>
+    <string name="login_page_topcomponent_text_korean" translatable="false">학생 정보 통합관리 서비스</string>
+    <string name="title_activity_fill_out_information" translatable="false">FillOutInformationActivity</string>
+    <string name="browser_error_title" translatable="false">Browser error</string>
+    <string name="browser_error_content" translatable="false">Browser not found.\nPlease connect after installing the browser.</string>
+    <string name="cansel" translatable="false">Cancel</string>
+    <string name="check" translatable="false">Check</string>
 </resources>


### PR DESCRIPTION
## 💡 개요
- 해외 기기에서 web브라우저가 존재하지 않을때 예외처리가 되지 않아 예외처리합니다.

## 📃 작업내용
- 안드로이드 장치에 설치된 브라우저 앱의 유무를 판단해서 예외를 처리합니다.

## 🔀 변경사항
- 앱 패키지 정보 접근 권한 허용
- 예외 다이얼로그 문자열 다국어 처리(한국어, 영어)
- 브라우저의 유무를 판단하는 함수 추가
- GAuth 버튼이 클릭되었을때 함수를 실행해서 예외 처리