### PR TITLE
🔀 :: (#406) 로그인한 유저의 마이페이지 nullable 처리

### DIFF
--- a/data/src/main/java/com/msg/sms/data/remote/dto/student/request/PutChangedProfileRequest.kt
+++ b/data/src/main/java/com/msg/sms/data/remote/dto/student/request/PutChangedProfileRequest.kt
@@ -15,7 +15,7 @@ data class PutChangedProfileRequest(
     @SerializedName("introduce")
     val introduce: String,
     @SerializedName("portfolioUrl")
-    val portfolioUrl: String,
+    val portfolioUrl: String?,
     @SerializedName("contactEmail")
     val contactEmail: String,
     @SerializedName("formOfEmployment")

--- a/data/src/main/java/com/msg/sms/data/remote/dto/user/response/GetMyProfileResponse.kt
+++ b/data/src/main/java/com/msg/sms/data/remote/dto/user/response/GetMyProfileResponse.kt
@@ -10,7 +10,7 @@ data class GetMyProfileResponse(
     @SerializedName("introduce")
     val introduce: String,
     @SerializedName("portfolioUrl")
-    val portfolioUrl: String,
+    val portfolioUrl: String?,
     @SerializedName("grade")
     val grade: Int,
     @SerializedName("classNum")

--- a/domain/src/main/java/com/msg/sms/domain/model/user/response/MyProfileModel.kt
+++ b/domain/src/main/java/com/msg/sms/domain/model/user/response/MyProfileModel.kt
@@ -3,7 +3,7 @@ package com.msg.sms.domain.model.user.response
 data class MyProfileModel(
     val name: String,
     val introduce: String,
-    val portfolioUrl: String,
+    val portfolioUrl: String?,
     val grade: Int,
     val classNum: Int,
     val number: Int,

--- a/presentation/src/main/java/com/sms/presentation/main/ui/mypage/component/profile/PortfolioComponent.kt
+++ b/presentation/src/main/java/com/sms/presentation/main/ui/mypage/component/profile/PortfolioComponent.kt
@@ -8,11 +8,11 @@ import com.msg.sms.design.component.textfield.SmsTextField
 import com.msg.sms.design.util.AddGrayBody1Title
 
 @Composable
-fun PortfolioComponent(portfolioValue: String, onValueChange: (value: String) -> Unit) {
+fun PortfolioComponent(portfolioValue: String?, onValueChange: (value: String) -> Unit) {
     AddGrayBody1Title(titleText = "포트폴리오 URL") {
         SmsTextField(
             modifier = Modifier.fillMaxWidth(),
-            setText = portfolioValue,
+            setText = portfolioValue?:"",
             placeHolder = "포트폴리오 URL",
             onValueChange = onValueChange) {
             onValueChange("")

--- a/presentation/src/main/java/com/sms/presentation/main/ui/mypage/state/MyProfileData.kt
+++ b/presentation/src/main/java/com/sms/presentation/main/ui/mypage/state/MyProfileData.kt
@@ -6,7 +6,7 @@ import com.msg.sms.domain.model.user.response.LanguageCertificateModel
 data class MyProfileData(
     val name: String,
     val introduce: String,
-    val portfolioUrl: String,
+    val portfolioUrl: String?,
     val grade: Int,
     val classNum: Int,
     val number: Int,


### PR DESCRIPTION
## 💡 개요
로그인한 유저의 마이페이지의 Response의 값이 null이 오는 경우가 생기는 곳을 찾아 nullable 처리 합니다.
## 📃 작업내용
PutChangedProfileRequest, GetMyProfileResponse 등 기존에 필수 값이 였던 것을 nullable 처리 합니다
## 🔀 변경사항
- PutChangedProfileRequest.kt의 potfolioUrl
- GetMyProfileResponse.kt의 potfolioUrl
- MyProfileModel.kt의 potfolioUrl
- PotfolioComponent.kt 의 potfolioValue
- MyProfileData의 potfolioUrl
등이 nullable 처리 되었습니다

## 🎸 기타
수정 사항에 따른 버튼의 활성화는 추가로 추가로 이슈를 생성할 계획입니다