### PR TITLE
🔀 :: (#419) - publishing input authentication

### DIFF
--- a/presentation/src/main/java/com/sms/presentation/main/ui/fill_out_authentication/FillOutAuthenticationScreen.kt
+++ b/presentation/src/main/java/com/sms/presentation/main/ui/fill_out_authentication/FillOutAuthenticationScreen.kt
@@ -1,0 +1,81 @@
+package com.sms.presentation.main.ui.fill_out_authentication
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.msg.sms.design.component.header.TitleHeader
+import com.msg.sms.design.component.spacer.SmsSpacer
+import com.msg.sms.design.component.topbar.TopBarComponent
+import com.msg.sms.design.icon.BackButtonIcon
+import com.msg.sms.design.icon.BlackLogoutIcon
+import com.sms.presentation.main.ui.fill_out_authentication.section.AuthenticationSection
+import com.sms.presentation.main.ui.fill_out_authentication.state.AuthenticationData
+import com.sms.presentation.main.ui.mypage.component.button.SaveButtonComponent
+
+@Composable
+fun FillOutAuthenticationScreen(
+    authenticationData: AuthenticationData,
+    onValueChange: (value: AuthenticationData) -> Unit,
+    onClickTopLeftButton: () -> Unit,
+    onClickTopRightButton: () -> Unit,
+    onSaveButtonClick: () -> Unit
+) {
+    val isButtonClicked = remember {
+        mutableStateOf(false)
+    }
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(color = Color.White)
+    ) {
+        TopBarComponent(
+            text = "마이페이지",
+            leftIcon = { BackButtonIcon() },
+            rightIcon = { BlackLogoutIcon() },
+            onClickRightButton = onClickTopRightButton,
+            onClickLeftButton = onClickTopLeftButton,
+        )
+        SmsSpacer()
+        TitleHeader(titleText = "인증제 *")
+        AuthenticationSection(
+            modifier = Modifier.weight(1f),
+            authenticationData = authenticationData,
+            onValueChange = onValueChange
+        )
+        SaveButtonComponent(
+            modifier = Modifier.padding(horizontal = 20.dp),
+            visibility = true,
+            enabled = !isButtonClicked.value,
+            onClickSaveButton = {
+                isButtonClicked.value = true
+                onSaveButtonClick()
+            }
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun FillOutAuthenticationScreenPre() {
+    FillOutAuthenticationScreen(
+        authenticationData = AuthenticationData(
+            title = "",
+            content = "",
+            activityImages = "",
+            activityImagesBitmap = null
+        ),
+        onValueChange = {},
+        onClickTopLeftButton = {},
+        onClickTopRightButton = {},
+        onSaveButtonClick = {}
+    )
+}

--- a/presentation/src/main/java/com/sms/presentation/main/ui/fill_out_authentication/component/ActivityDescriptionComponent.kt
+++ b/presentation/src/main/java/com/sms/presentation/main/ui/fill_out_authentication/component/ActivityDescriptionComponent.kt
@@ -1,0 +1,32 @@
+package com.sms.presentation.main.ui.fill_out_authentication.component
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import com.msg.sms.design.component.textfield.SmsTextField
+import com.msg.sms.design.util.AddGrayBody1Title
+
+@Composable
+fun ActivityDescriptionComponent(
+    modifier: Modifier,
+    activityDescriptionValue: String,
+    onValueChange: (value: String) -> Unit
+) {
+    AddGrayBody1Title(titleText = "활동 설명") {
+        SmsTextField(
+            modifier = modifier.fillMaxWidth(),
+            setText = activityDescriptionValue,
+            placeHolder = "활동 설명 입력",
+            onValueChange = onValueChange
+        ) {
+            onValueChange("")
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun ActivityDescriptionComponentPre() {
+    ActivityDescriptionComponent(Modifier,"Droid Knights 2024", onValueChange = {})
+}

--- a/presentation/src/main/java/com/sms/presentation/main/ui/fill_out_authentication/component/ActivityTitleComponent.kt
+++ b/presentation/src/main/java/com/sms/presentation/main/ui/fill_out_authentication/component/ActivityTitleComponent.kt
@@ -1,0 +1,31 @@
+package com.sms.presentation.main.ui.fill_out_authentication.component
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import com.msg.sms.design.component.textfield.SmsTextField
+import com.msg.sms.design.util.AddGrayBody1Title
+
+@Composable
+fun ActivityTitleComponent(
+    activityTitleValue: String,
+    onValueChange: (value: String) -> Unit
+) {
+    AddGrayBody1Title(titleText = "활동 제목") {
+        SmsTextField(
+            modifier = Modifier.fillMaxWidth(),
+            setText = activityTitleValue,
+            placeHolder = "활동 제목 입력",
+            onValueChange = onValueChange
+        ) {
+            onValueChange("")
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun ActivityTitleComponentPre() {
+    ActivityTitleComponent("Droid Knights 2024", onValueChange = {})
+}

--- a/presentation/src/main/java/com/sms/presentation/main/ui/fill_out_authentication/component/PictureComponent.kt
+++ b/presentation/src/main/java/com/sms/presentation/main/ui/fill_out_authentication/component/PictureComponent.kt
@@ -1,0 +1,82 @@
+package com.sms.presentation.main.ui.fill_out_authentication.component
+
+import android.graphics.Bitmap
+import android.graphics.ImageDecoder
+import android.net.Uri
+import android.os.Build
+import android.provider.MediaStore
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import coil.compose.rememberAsyncImagePainter
+import com.msg.sms.design.modifier.smsClickable
+import com.msg.sms.design.util.AddGrayBody1Title
+
+@Composable
+fun PicturePickerComponent(
+    imageUrl: String,
+    bitmapImage: Bitmap?,
+    onChangeMyProfileImage: (value: Bitmap) -> Unit
+) {
+    val context = LocalContext.current
+    val launcher =
+        rememberLauncherForActivityResult(contract = ActivityResultContracts.GetContent()) { uri: Uri? ->
+            if (uri != null) {
+                if (Build.VERSION.SDK_INT < 28) {
+                    onChangeMyProfileImage(
+                        MediaStore.Images.Media.getBitmap(context.contentResolver, uri)
+                    )
+                } else {
+                    val source = ImageDecoder.createSource(context.contentResolver, uri)
+                    onChangeMyProfileImage(ImageDecoder.decodeBitmap(source))
+                }
+            }
+        }
+
+    AddGrayBody1Title(titleText = "사진") {
+        if (bitmapImage == null) {
+            Image(
+                modifier = Modifier
+                    .size(168.dp)
+                    .clip(RoundedCornerShape(8.dp))
+                    .smsClickable {
+                        launcher.launch("image/*")
+                    },
+                painter = rememberAsyncImagePainter(model = imageUrl),
+                contentScale = ContentScale.Crop,
+                contentDescription = "인증제 이미지"
+            )
+        } else {
+            Image(
+                modifier = Modifier
+                    .size(168.dp)
+                    .clip(RoundedCornerShape(8.dp))
+                    .smsClickable {
+                        launcher.launch("image/*")
+                    },
+                bitmap = bitmapImage.asImageBitmap(),
+                contentScale = ContentScale.Crop,
+                contentDescription = "인증제 이미지"
+            )
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun PicturePickerComponentPre() {
+    PicturePickerComponent(
+        imageUrl = "https://avatars.githubusercontent.com/u/82383983?s=400&u=776e1d000088224cbabf4dec2bdea03071aaaef2&v=4",
+        bitmapImage = null,
+        onChangeMyProfileImage = {})
+}

--- a/presentation/src/main/java/com/sms/presentation/main/ui/fill_out_authentication/section/AuthenticationSection.kt
+++ b/presentation/src/main/java/com/sms/presentation/main/ui/fill_out_authentication/section/AuthenticationSection.kt
@@ -1,0 +1,42 @@
+package com.sms.presentation.main.ui.fill_out_authentication.section
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.sms.presentation.main.ui.fill_out_authentication.component.ActivityDescriptionComponent
+import com.sms.presentation.main.ui.fill_out_authentication.component.ActivityTitleComponent
+import com.sms.presentation.main.ui.fill_out_authentication.component.PicturePickerComponent
+import com.sms.presentation.main.ui.fill_out_authentication.state.AuthenticationData
+
+@Composable
+fun AuthenticationSection(
+    modifier: Modifier,
+    authenticationData: AuthenticationData,
+    onValueChange: (value: AuthenticationData) -> Unit
+) {
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(top = 24.dp, start = 20.dp, end = 20.dp, bottom = 20.dp),
+        verticalArrangement = Arrangement.spacedBy(24.dp)
+    ) {
+        PicturePickerComponent(
+            onChangeMyProfileImage = { onValueChange(authenticationData.copy(activityImagesBitmap = it)) },
+            imageUrl = authenticationData.activityImages,
+            bitmapImage = authenticationData.activityImagesBitmap,
+        )
+        ActivityTitleComponent(
+            activityTitleValue = authenticationData.title,
+            onValueChange = { onValueChange(authenticationData.copy(title = it)) }
+        )
+        ActivityDescriptionComponent(
+            modifier = Modifier.weight(1f),
+            activityDescriptionValue = authenticationData.content,
+            onValueChange = { onValueChange(authenticationData.copy(content = it)) }
+        )
+    }
+}

--- a/presentation/src/main/java/com/sms/presentation/main/ui/fill_out_authentication/state/AuthenticationData.kt
+++ b/presentation/src/main/java/com/sms/presentation/main/ui/fill_out_authentication/state/AuthenticationData.kt
@@ -1,0 +1,10 @@
+package com.sms.presentation.main.ui.fill_out_authentication.state
+
+import android.graphics.Bitmap
+
+data class AuthenticationData(
+    val title: String,
+    val content: String,
+    val activityImages: String,
+    val activityImagesBitmap: Bitmap? = null
+)


### PR DESCRIPTION
## 💡 개요
- 인증제 입력 페이지 퍼블리싱

## 📃 작업내용
<img width="311" alt="image" src="https://github.com/GSM-MSG/SMS-Android/assets/103114398/1bfead53-f4eb-4820-935f-6f60512b7924">

## 🔀 변경사항
- 인증제 입력 페이지를 퍼블리싱 했습니다.