### PR TITLE
Feature/438 add sharing information UI

### DIFF
--- a/presentation/src/main/java/com/sms/presentation/main/ui/detail/StudentDetailComponent.kt
+++ b/presentation/src/main/java/com/sms/presentation/main/ui/detail/StudentDetailComponent.kt
@@ -143,7 +143,7 @@ fun StudentDetailComponent(
                             SmsRoundedButton(
                                 text = "공유",
                                 modifier = Modifier
-                                    .fillMaxWidth(0.385f),
+                                    .fillMaxWidth(0.95f),
                                 state = ButtonState.OutLine
                             ) {
 

--- a/presentation/src/main/java/com/sms/presentation/main/ui/detail/StudentDetailComponent.kt
+++ b/presentation/src/main/java/com/sms/presentation/main/ui/detail/StudentDetailComponent.kt
@@ -7,11 +7,13 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
@@ -23,6 +25,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import com.msg.sms.design.component.button.ButtonState
 import com.msg.sms.design.component.button.SmsRoundedButton
 import com.msg.sms.domain.model.common.CertificateModel
 import com.sms.presentation.main.ui.detail.award.AwardComponent
@@ -121,16 +124,30 @@ fun StudentDetailComponent(
                         ProjectListComponent(projectList = projectList)
                     }
                     if(isTeacher) {
-                        SmsRoundedButton(
-                            text = "포트폴리오",
+                        Row (
                             modifier = Modifier
-                                .fillMaxWidth()
-                        ) {
-                            val urlIntent = Intent(
-                                Intent.ACTION_VIEW,
-                                Uri.parse(portfolioLink)
-                            )
-                            context.startActivity(urlIntent)
+                                .padding(horizontal = 8.dp)
+                        ){
+                            SmsRoundedButton(
+                                text = "포트폴리오",
+                                modifier = Modifier
+                                    .fillMaxWidth(0.685f)
+                            ) {
+                                val urlIntent = Intent(
+                                    Intent.ACTION_VIEW,
+                                    Uri.parse(portfolioLink)
+                                )
+                                context.startActivity(urlIntent)
+                            }
+                            Spacer(modifier = Modifier.width(8.dp))
+                            SmsRoundedButton(
+                                text = "공유",
+                                modifier = Modifier
+                                    .fillMaxWidth(0.385f),
+                                state = ButtonState.OutLine
+                            ) {
+
+                            }
                         }
                     }
                 }

--- a/presentation/src/main/java/com/sms/presentation/main/ui/detail/dialog/CopyLinkDialog.kt
+++ b/presentation/src/main/java/com/sms/presentation/main/ui/detail/dialog/CopyLinkDialog.kt
@@ -89,9 +89,7 @@ fun CopyLinkDialog(
                     Spacer(modifier = Modifier.size(24.dp))
                     Row (
                         modifier = Modifier
-                            .clip(
-                                RoundedCornerShape(12.dp)
-                            )
+                            .clip(RoundedCornerShape(12.dp))
                             .background(color = colors.N10)
                             .fillMaxWidth()
                             .fillMaxHeight(0.39f)
@@ -99,10 +97,7 @@ fun CopyLinkDialog(
                         Text(
                             text = "https://blog.naver.com.ds...",
                             modifier = Modifier
-                                .padding(
-                                    vertical = 13.5.dp,
-                                    horizontal = 12.dp
-                                )
+                                .padding(vertical = 13.5.dp, horizontal = 12.dp)
                         )
                         Spacer(modifier = Modifier.width(8.dp))
                         Button(

--- a/presentation/src/main/java/com/sms/presentation/main/ui/detail/dialog/CopyLinkDialog.kt
+++ b/presentation/src/main/java/com/sms/presentation/main/ui/detail/dialog/CopyLinkDialog.kt
@@ -1,0 +1,171 @@
+package com.sms.presentation.main.ui.detail.dialog
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Button
+import androidx.compose.material.ButtonDefaults
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import com.msg.sms.design.component.button.ButtonState
+import com.msg.sms.design.component.button.SmsRoundedButton
+import com.msg.sms.design.theme.SMSTheme
+
+@Composable
+fun CopyLinkDialog(
+    widthPercent: Float? = null,
+    widthDp: Dp? = null,
+    heightPercent: Float? = null,
+    heightDp: Dp? = null,
+    betweenTextAndButtonHeight: Dp? = null,
+    cancelButtonEnabled: Boolean = false,
+    isError: Boolean = false,
+    title: String,
+    outLineButtonText: String,
+    importantButtonText: String,
+    outlineButtonOnClick: () -> Unit,
+    importantButtonOnClick: () -> Unit,
+    onDismissRequest: () -> Unit = {},
+) {
+    val modifier = when {
+        widthPercent != null && heightPercent != null -> {
+            Modifier
+                .fillMaxWidth(widthPercent)
+                .fillMaxHeight(heightPercent)
+        }
+
+        widthDp != null && heightDp != null -> {
+            Modifier
+                .width(widthDp)
+                .height(heightDp)
+        }
+
+        else -> {
+            Modifier
+                .width(330.dp)
+                .height(180.dp)
+        }
+    }
+
+    SMSTheme { colors, typography ->
+        Dialog(
+            onDismissRequest = { onDismissRequest() }
+        ) {
+            Box(
+                modifier = modifier
+                    .clip(RoundedCornerShape(16.dp))
+                    .background(colors.WHITE)
+            ) {
+                Column(
+                    modifier = Modifier
+                        .align(Alignment.TopStart)
+                        .padding(24.dp)
+                ) {
+                    Text(
+                        text = title,
+                        style = typography.title2,
+                        fontWeight = FontWeight.Bold
+                    )
+                    Spacer(modifier = Modifier.size(24.dp))
+                    Row (
+                        modifier = Modifier
+                            .clip(
+                                RoundedCornerShape(12.dp)
+                            )
+                            .background(color = colors.N10)
+                            .fillMaxWidth()
+                            .fillMaxHeight(0.39f)
+                    ){
+                        Text(
+                            text = "https://blog.naver.com.ds...",
+                            modifier = Modifier
+                                .padding(
+                                    vertical = 13.5.dp,
+                                    horizontal = 12.dp
+                                )
+                        )
+                        Spacer(modifier = Modifier.width(8.dp))
+                        Button(
+                            onClick = {  },
+                            modifier = Modifier
+                                .padding(end = 12.dp, top = 8.5.dp, bottom = 8.5.dp),
+                            border = BorderStroke(1.dp, colors.P2),
+                            shape = RoundedCornerShape(30.dp),
+                            colors = ButtonDefaults.outlinedButtonColors(contentColor = colors.P2),
+                            contentPadding = PaddingValues(0.dp)
+                        ) {
+                            Text(
+                                text = "복사",
+                                textAlign = TextAlign.Center,
+                                modifier = Modifier
+                                    .padding(horizontal = 14.dp, vertical = 5.dp),
+                                color = colors.P2
+                            )
+                        }
+                    }
+                    if (betweenTextAndButtonHeight != null)
+                        Spacer(modifier = Modifier.height(betweenTextAndButtonHeight))
+                }
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(24.dp)
+                        .align(Alignment.BottomCenter)
+                ) {
+                    if (cancelButtonEnabled) {
+                        SmsRoundedButton(
+                            text = outLineButtonText,
+                            state = ButtonState.OutLine,
+                            modifier = Modifier
+                                .fillMaxWidth(0.485f)
+                                .align(Alignment.CenterStart),
+                            onClick = outlineButtonOnClick
+                        )
+                    }
+                    SmsRoundedButton(
+                        text = importantButtonText,
+                        state = if (isError) ButtonState.Error else ButtonState.Normal,
+                        modifier = Modifier
+                            .fillMaxWidth(0.485f)
+                            .align(Alignment.CenterEnd),
+                        onClick = importantButtonOnClick
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Preview
+@Composable
+fun LinkDialogPre() {
+    CopyLinkDialog(
+        title = "만료일 선택",
+        outLineButtonText = "",
+        importantButtonText = "확인",
+        outlineButtonOnClick = { /*TODO*/ },
+        importantButtonOnClick = { /*TODO*/ },
+        widthDp = 328.dp,
+        heightDp = 226.dp
+    )
+}

--- a/presentation/src/main/java/com/sms/presentation/main/ui/detail/dialog/CopyLinkDialog.kt
+++ b/presentation/src/main/java/com/sms/presentation/main/ui/detail/dialog/CopyLinkDialog.kt
@@ -2,6 +2,7 @@ package com.sms.presentation.main.ui.detail.dialog
 
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
@@ -90,6 +91,7 @@ fun CopyLinkDialog(
                     Row (
                         modifier = Modifier
                             .clip(RoundedCornerShape(12.dp))
+                            .border(1.dp, color = colors.N20, shape = RoundedCornerShape(12.dp))
                             .background(color = colors.N10)
                             .fillMaxWidth()
                             .fillMaxHeight(0.39f)

--- a/presentation/src/main/java/com/sms/presentation/main/ui/detail/dialog/SelectExpirationDateDialog.kt
+++ b/presentation/src/main/java/com/sms/presentation/main/ui/detail/dialog/SelectExpirationDateDialog.kt
@@ -1,20 +1,20 @@
 package com.sms.presentation.main.ui.detail.dialog
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.RadioButtonColors
 import androidx.compose.material.Text
 import androidx.compose.material3.RadioButton
 import androidx.compose.material3.RadioButtonDefaults
@@ -73,7 +73,7 @@ fun SelectExpirationDateDialog(
 
     var selectedOption by remember { mutableStateOf("30일") }
 
-    val options = listOf("5일", "20일", "10일", "25일", "15일", "30일")
+    val options = listOf("5일", "10일", "15일", "20일", "25일", "30일")
 
     SMSTheme { colors, typography ->
         Dialog(
@@ -97,34 +97,23 @@ fun SelectExpirationDateDialog(
                     if (betweenTextAndButtonHeight != null)
                         Spacer(modifier = Modifier.height(betweenTextAndButtonHeight))
                 }
-                Column(
-                    modifier = Modifier
-                        .padding(start = 10.dp, top = 50.dp)
-                ){
-                    options.chunked(2).forEach { rowOptions ->
+                LazyVerticalGrid(
+                    modifier = Modifier.padding(top = 50.dp),
+                    columns = GridCells.Fixed(2),
+                    contentPadding = PaddingValues(horizontal = 8.dp),
+                ) {
+                    items(options) { text ->
                         Row(
-                            horizontalArrangement = Arrangement.Start,
-                            verticalAlignment = Alignment.CenterVertically
+                            verticalAlignment = Alignment.CenterVertically,
                         ) {
-                            rowOptions.forEach { text ->
-                                Row(
-                                    verticalAlignment = Alignment.CenterVertically,
-                                    modifier = Modifier
-                                        .weight(0.1f)
-
-                                ) {
-                                    RadioButton(
-                                        selected = (text == selectedOption),
-                                        onClick = { selectedOption = text },
-                                        colors = RadioButtonDefaults.colors(
-                                            selectedColor = colors.P2
-                                        )
-                                    )
-                                    Text(
-                                        text = text,
-                                    )
-                                }
-                            }
+                            RadioButton(
+                                selected = (text == selectedOption),
+                                onClick = { selectedOption = text },
+                                colors = RadioButtonDefaults.colors(
+                                    selectedColor = colors.P2
+                                )
+                            )
+                            Text(text = text)
                         }
                     }
                 }

--- a/presentation/src/main/java/com/sms/presentation/main/ui/detail/dialog/SelectExpirationDateDialog.kt
+++ b/presentation/src/main/java/com/sms/presentation/main/ui/detail/dialog/SelectExpirationDateDialog.kt
@@ -1,0 +1,173 @@
+package com.sms.presentation.main.ui.detail.dialog
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.RadioButtonColors
+import androidx.compose.material.Text
+import androidx.compose.material3.RadioButton
+import androidx.compose.material3.RadioButtonDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import com.msg.sms.design.component.button.ButtonState
+import com.msg.sms.design.component.button.SmsRoundedButton
+import com.msg.sms.design.theme.SMSTheme
+
+@Composable
+fun SelectExpirationDateDialog(
+    widthPercent: Float? = null,
+    widthDp: Dp? = null,
+    heightPercent: Float? = null,
+    heightDp: Dp? = null,
+    betweenTextAndButtonHeight: Dp? = null,
+    cancelButtonEnabled: Boolean = true,
+    isError: Boolean = false,
+    title: String,
+    outLineButtonText: String,
+    importantButtonText: String,
+    outlineButtonOnClick: () -> Unit,
+    importantButtonOnClick: () -> Unit,
+    onDismissRequest: () -> Unit = {},
+) {
+    val modifier = when {
+        widthPercent != null && heightPercent != null -> {
+            Modifier
+                .fillMaxWidth(widthPercent)
+                .fillMaxHeight(heightPercent)
+        }
+
+        widthDp != null && heightDp != null -> {
+            Modifier
+                .width(widthDp)
+                .height(heightDp)
+        }
+
+        else -> {
+            Modifier
+                .width(330.dp)
+                .height(180.dp)
+        }
+    }
+
+    var selectedOption by remember { mutableStateOf("30일") }
+
+    val options = listOf("5일", "20일", "10일", "25일", "15일", "30일")
+
+    SMSTheme { colors, typography ->
+        Dialog(
+            onDismissRequest = { onDismissRequest() }
+        ) {
+            Box(
+                modifier = modifier
+                    .clip(RoundedCornerShape(16.dp))
+                    .background(colors.WHITE)
+            ) {
+                Column(
+                    modifier = Modifier
+                        .align(Alignment.TopStart)
+                        .padding(24.dp)
+                ) {
+                    Text(
+                        text = title,
+                        style = typography.title2,
+                        fontWeight = FontWeight.Bold
+                    )
+                    if (betweenTextAndButtonHeight != null)
+                        Spacer(modifier = Modifier.height(betweenTextAndButtonHeight))
+                }
+                Column(
+                    modifier = Modifier
+                        .padding(start = 10.dp, top = 50.dp)
+                ){
+                    options.chunked(2).forEach { rowOptions ->
+                        Row(
+                            horizontalArrangement = Arrangement.Start,
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            rowOptions.forEach { text ->
+                                Row(
+                                    verticalAlignment = Alignment.CenterVertically,
+                                    modifier = Modifier
+                                        .weight(0.1f)
+
+                                ) {
+                                    RadioButton(
+                                        selected = (text == selectedOption),
+                                        onClick = { selectedOption = text },
+                                        colors = RadioButtonDefaults.colors(
+                                            selectedColor = colors.P2
+                                        )
+                                    )
+                                    Text(
+                                        text = text,
+                                    )
+                                }
+                            }
+                        }
+                    }
+                }
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(24.dp)
+                        .align(Alignment.BottomCenter)
+                ) {
+                    if (cancelButtonEnabled) {
+                        SmsRoundedButton(
+                            text = outLineButtonText,
+                            state = ButtonState.OutLine,
+                            modifier = Modifier
+                                .fillMaxWidth(0.485f)
+                                .align(Alignment.CenterStart),
+                            onClick = outlineButtonOnClick
+                        )
+                    }
+                    SmsRoundedButton(
+                        text = importantButtonText,
+                        state = if (isError) ButtonState.Error else ButtonState.Normal,
+                        modifier = Modifier
+                            .fillMaxWidth(if (cancelButtonEnabled) 0.485f else 1f)
+                            .align(Alignment.CenterEnd),
+                        onClick = importantButtonOnClick
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Preview
+@Composable
+fun DialogPre() {
+    SelectExpirationDateDialog(
+        title = "만료기간 선택",
+        outLineButtonText = "취소",
+        importantButtonText = "링크 생성",
+        outlineButtonOnClick = { /*TODO*/ },
+        importantButtonOnClick = { /*TODO*/ },
+        widthDp = 328.dp,
+        heightDp = 280.dp
+    )
+}


### PR DESCRIPTION
## 💡 개요
드림북 링크 공유 컴포넌트 퍼블리싱
## 📃 작업내용
<img width="239" alt="스크린샷 2024-06-05 오전 11 54 47" src="https://github.com/GSM-MSG/SMS-Android/assets/105362474/fb766e08-0b4e-47ff-86aa-b27f9b3d8bde">
학생 상세정보 페이지에 공유 버튼 컴포넌트를 생성하였습니다.
<img width="351" alt="스크린샷 2024-06-05 오후 2 06 09" src="https://github.com/GSM-MSG/SMS-Android/assets/103114398/3dc029ae-80ed-4404-8145-9c11de79e39f">
공유 버튼 컴포넌트에 반응 하는 만료일 설정 다이얼로그 컴포넌트를 생성하였습니다.

<img width="256" alt="스크린샷 2024-06-05 오전 11 57 20" src="https://github.com/GSM-MSG/SMS-Android/assets/105362474/2e32c177-075a-4d65-82e0-5cf2f5db7afb">
생성된 링크를 보여주는 다이얼로그 컴포넌트를 생성하였습니다.

## 🎸 기타
다이얼로그를 연결하거나 데이터를 enum class로 관리하거나 하는 작업은 로직을 작성할 때 추가 할 예정입니다.