### PR TITLE
🔀 :: (#466) - write the logic portfolio file upload

### DIFF
--- a/data/src/main/java/com/msg/sms/data/remote/datasource/student/RemoteStudentDataSource.kt
+++ b/data/src/main/java/com/msg/sms/data/remote/datasource/student/RemoteStudentDataSource.kt
@@ -7,6 +7,7 @@ import com.msg.sms.data.remote.dto.student.response.CreateInformationLinkRespons
 import com.msg.sms.data.remote.dto.student.response.GetStudentResponse
 import com.msg.sms.data.remote.dto.student.response.GetStudentListResponse
 import kotlinx.coroutines.flow.Flow
+import okhttp3.MultipartBody
 import java.util.*
 
 interface RemoteStudentDataSource {
@@ -37,4 +38,6 @@ interface RemoteStudentDataSource {
     suspend fun putChangedProfile(body: PutChangedProfileRequest): Flow<Unit>
 
     suspend fun createInformationLink(body: CreateInformationLinkRequest): Flow<CreateInformationLinkResponse>
+
+    suspend fun putChangedPortfolioPdf(file: MultipartBody.Part): Flow<Unit>
 }

--- a/data/src/main/java/com/msg/sms/data/remote/datasource/student/RemoteStudentDataSourceImpl.kt
+++ b/data/src/main/java/com/msg/sms/data/remote/datasource/student/RemoteStudentDataSourceImpl.kt
@@ -1,5 +1,6 @@
 package com.msg.sms.data.remote.datasource.student
 
+import android.util.Log
 import com.msg.sms.data.remote.dto.student.request.CreateInformationLinkRequest
 import com.msg.sms.data.remote.dto.student.request.EnterStudentInformationRequest
 import com.msg.sms.data.remote.dto.student.request.PutChangedProfileRequest
@@ -12,6 +13,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOn
+import okhttp3.MultipartBody
 import java.util.UUID
 import javax.inject.Inject
 
@@ -116,6 +118,17 @@ class RemoteStudentDataSourceImpl @Inject constructor(
             emit(SMSApiHandler<CreateInformationLinkResponse>().httpRequest {
                 service.createInformationLink(body = body)
             }.sendRequest())
+        }.flowOn(Dispatchers.IO)
+    }
+
+    override suspend fun putChangedPortfolioPdf(file: MultipartBody.Part): Flow<Unit> {
+        Log.d("testt-start", file.toString())
+        SMSApiHandler<Unit>().httpRequest {
+            service.putChangedPortfolioPdf(file = file)
+            Log.d("testt-end", file.toString())
+        }.sendRequest()
+        return flow {
+            emit(Unit)
         }.flowOn(Dispatchers.IO)
     }
 }

--- a/data/src/main/java/com/msg/sms/data/remote/datasource/student/RemoteStudentDataSourceImpl.kt
+++ b/data/src/main/java/com/msg/sms/data/remote/datasource/student/RemoteStudentDataSourceImpl.kt
@@ -1,6 +1,5 @@
 package com.msg.sms.data.remote.datasource.student
 
-import android.util.Log
 import com.msg.sms.data.remote.dto.student.request.CreateInformationLinkRequest
 import com.msg.sms.data.remote.dto.student.request.EnterStudentInformationRequest
 import com.msg.sms.data.remote.dto.student.request.PutChangedProfileRequest
@@ -122,10 +121,8 @@ class RemoteStudentDataSourceImpl @Inject constructor(
     }
 
     override suspend fun putChangedPortfolioPdf(file: MultipartBody.Part): Flow<Unit> {
-        Log.d("testt-start", file.toString())
         SMSApiHandler<Unit>().httpRequest {
             service.putChangedPortfolioPdf(file = file)
-            Log.d("testt-end", file.toString())
         }.sendRequest()
         return flow {
             emit(Unit)

--- a/data/src/main/java/com/msg/sms/data/remote/datasource/student/RemoteStudentDataSourceImpl.kt
+++ b/data/src/main/java/com/msg/sms/data/remote/datasource/student/RemoteStudentDataSourceImpl.kt
@@ -121,11 +121,10 @@ class RemoteStudentDataSourceImpl @Inject constructor(
     }
 
     override suspend fun putChangedPortfolioPdf(file: MultipartBody.Part): Flow<Unit> {
-        SMSApiHandler<Unit>().httpRequest {
-            service.putChangedPortfolioPdf(file = file)
-        }.sendRequest()
         return flow {
-            emit(Unit)
+            emit(SMSApiHandler<Unit>().httpRequest {
+                service.putChangedPortfolioPdf(file = file)
+            }.sendRequest())
         }.flowOn(Dispatchers.IO)
     }
 }

--- a/data/src/main/java/com/msg/sms/data/remote/dto/user/response/GetMyProfileResponse.kt
+++ b/data/src/main/java/com/msg/sms/data/remote/dto/user/response/GetMyProfileResponse.kt
@@ -11,6 +11,8 @@ data class GetMyProfileResponse(
     val introduce: String,
     @SerializedName("portfolioUrl")
     val portfolioUrl: String?,
+    @SerializedName("portfolioFileUrl")
+    val portfolioFileUrl: String?,
     @SerializedName("grade")
     val grade: Int,
     @SerializedName("classNum")
@@ -52,6 +54,7 @@ fun GetMyProfileResponse.toMyProfileModel(): MyProfileModel {
         name = this.name,
         introduce = this.introduce,
         portfolioUrl = this.portfolioUrl,
+        portfolioFileUrl = this.portfolioFileUrl,
         grade = this.grade,
         classNum = this.classNum,
         number = this.number,

--- a/data/src/main/java/com/msg/sms/data/remote/network/api/StudentAPI.kt
+++ b/data/src/main/java/com/msg/sms/data/remote/network/api/StudentAPI.kt
@@ -6,6 +6,7 @@ import com.msg.sms.data.remote.dto.student.request.PutChangedProfileRequest
 import com.msg.sms.data.remote.dto.student.response.CreateInformationLinkResponse
 import com.msg.sms.data.remote.dto.student.response.GetStudentResponse
 import com.msg.sms.data.remote.dto.student.response.GetStudentListResponse
+import okhttp3.MultipartBody
 import retrofit2.http.*
 import java.util.*
 
@@ -54,4 +55,10 @@ interface StudentAPI {
     suspend fun createInformationLink (
         @Body body: CreateInformationLinkRequest
     ): CreateInformationLinkResponse
+
+    @Multipart
+    @PUT("student/pdf")
+    suspend fun putChangedPortfolioPdf(
+        @Part file: MultipartBody.Part
+    )
 }

--- a/data/src/main/java/com/msg/sms/data/repository/StudentRepositoryImpl.kt
+++ b/data/src/main/java/com/msg/sms/data/repository/StudentRepositoryImpl.kt
@@ -14,13 +14,14 @@ import com.msg.sms.data.remote.dto.student.response.toGetStudentForTeacherModel
 import com.msg.sms.data.remote.dto.student.response.toStudentListModel
 import com.msg.sms.domain.model.student.request.CreateInformationLinkRequestModel
 import com.msg.sms.domain.model.student.request.EnterStudentInformationModel
+import com.msg.sms.domain.model.student.request.PutChangeProfileRequestModel
 import com.msg.sms.domain.model.student.response.CreateInformationLinkResponseModel
 import com.msg.sms.domain.model.student.response.GetStudentModel
 import com.msg.sms.domain.model.student.response.StudentListModel
-import com.msg.sms.domain.model.user.response.MyProfileModel
 import com.msg.sms.domain.repository.StudentRepository
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
+import okhttp3.MultipartBody
 import java.util.UUID
 import javax.inject.Inject
 
@@ -80,7 +81,7 @@ class StudentRepositoryImpl @Inject constructor(
         else dataSource.getUserDetailRole(role = role, uuid = uuid).map { it.toGetStudentForTeacherModel() }
     }
 
-    override suspend fun putChangedProfile(profile: MyProfileModel): Flow<Unit> {
+    override suspend fun putChangedProfile(profile: PutChangeProfileRequestModel): Flow<Unit> {
         return dataSource.putChangedProfile(
             body = PutChangedProfileRequest(
                 major = profile.major,
@@ -134,5 +135,9 @@ class StudentRepositoryImpl @Inject constructor(
                 periodDay = body.periodDay
             )
         ).map { it.toCreateInformationLinkModel() }
+    }
+
+    override suspend fun putChangedPortfolioPdf(file: MultipartBody.Part): Flow<Unit> {
+        return dataSource.putChangedPortfolioPdf(file = file)
     }
 }

--- a/domain/src/main/java/com/msg/sms/domain/model/student/request/PutChangeProfileRequestModel.kt
+++ b/domain/src/main/java/com/msg/sms/domain/model/student/request/PutChangeProfileRequestModel.kt
@@ -1,0 +1,29 @@
+package com.msg.sms.domain.model.student.request
+
+import com.msg.sms.domain.model.common.PrizeModel
+import com.msg.sms.domain.model.common.ProjectModel
+import com.msg.sms.domain.model.user.response.LanguageCertificateModel
+
+data class PutChangeProfileRequestModel(
+    val name: String,
+    val introduce: String,
+    val portfolioUrl: String?,
+    val portfolioFileUrl: String?,
+    val grade: Int,
+    val classNum: Int,
+    val number: Int,
+    val department: String,
+    val major: String,
+    val profileImg: String,
+    val contactEmail: String,
+    val gsmAuthenticationScore: Int,
+    val formOfEmployment: String,
+    val regions: List<String>,
+    val militaryService: String,
+    val salary: Int,
+    val languageCertificates: List<LanguageCertificateModel>,
+    val certificates: List<String>,
+    val techStacks: List<String>,
+    val projects: List<ProjectModel>,
+    val prizes: List<PrizeModel>
+)

--- a/domain/src/main/java/com/msg/sms/domain/model/user/response/MyProfileModel.kt
+++ b/domain/src/main/java/com/msg/sms/domain/model/user/response/MyProfileModel.kt
@@ -7,6 +7,7 @@ data class MyProfileModel(
     val name: String,
     val introduce: String,
     val portfolioUrl: String?,
+    val portfolioFileUrl: String?,
     val grade: Int,
     val classNum: Int,
     val number: Int,

--- a/domain/src/main/java/com/msg/sms/domain/repository/StudentRepository.kt
+++ b/domain/src/main/java/com/msg/sms/domain/repository/StudentRepository.kt
@@ -2,11 +2,12 @@ package com.msg.sms.domain.repository
 
 import com.msg.sms.domain.model.student.request.CreateInformationLinkRequestModel
 import com.msg.sms.domain.model.student.request.EnterStudentInformationModel
+import com.msg.sms.domain.model.student.request.PutChangeProfileRequestModel
 import com.msg.sms.domain.model.student.response.CreateInformationLinkResponseModel
 import com.msg.sms.domain.model.student.response.GetStudentModel
 import com.msg.sms.domain.model.student.response.StudentListModel
-import com.msg.sms.domain.model.user.response.MyProfileModel
 import kotlinx.coroutines.flow.Flow
+import okhttp3.MultipartBody
 import java.util.UUID
 
 interface StudentRepository {
@@ -32,7 +33,9 @@ interface StudentRepository {
 
     suspend fun getUserDetail(role: String, uuid: UUID): Flow<GetStudentModel>
 
-    suspend fun putChangedProfile(profile: MyProfileModel): Flow<Unit>
+    suspend fun putChangedProfile(profile: PutChangeProfileRequestModel): Flow<Unit>
 
     suspend fun createInformationLink(body: CreateInformationLinkRequestModel): Flow<CreateInformationLinkResponseModel>
+
+    suspend fun putChangedPortfolioPdf(file: MultipartBody.Part): Flow<Unit>
 }

--- a/domain/src/main/java/com/msg/sms/domain/usecase/student/PutChangedPortfolioPdfUseCase.kt
+++ b/domain/src/main/java/com/msg/sms/domain/usecase/student/PutChangedPortfolioPdfUseCase.kt
@@ -1,0 +1,13 @@
+package com.msg.sms.domain.usecase.student
+
+import com.msg.sms.domain.repository.StudentRepository
+import okhttp3.MultipartBody
+import javax.inject.Inject
+
+class PutChangedPortfolioPdfUseCase @Inject constructor(
+    private val repository: StudentRepository
+) {
+    suspend operator fun invoke(file: MultipartBody.Part) = kotlin.runCatching {
+        repository.putChangedPortfolioPdf(file = file)
+    }
+}

--- a/domain/src/main/java/com/msg/sms/domain/usecase/student/PutChangedProfileUseCase.kt
+++ b/domain/src/main/java/com/msg/sms/domain/usecase/student/PutChangedProfileUseCase.kt
@@ -1,13 +1,13 @@
 package com.msg.sms.domain.usecase.student
 
-import com.msg.sms.domain.model.user.response.MyProfileModel
+import com.msg.sms.domain.model.student.request.PutChangeProfileRequestModel
 import com.msg.sms.domain.repository.StudentRepository
 import javax.inject.Inject
 
 class PutChangedProfileUseCase @Inject constructor(
     private val repository: StudentRepository,
 ) {
-    suspend operator fun invoke(profile: MyProfileModel) = kotlin.runCatching {
+    suspend operator fun invoke(profile: PutChangeProfileRequestModel) = kotlin.runCatching {
         repository.putChangedProfile(profile = profile)
     }
 }

--- a/presentation/src/main/java/com/sms/presentation/main/ui/mypage/MyPageScreen.kt
+++ b/presentation/src/main/java/com/sms/presentation/main/ui/mypage/MyPageScreen.kt
@@ -17,6 +17,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -99,6 +100,7 @@ fun MyPageScreen(
     onAwardValueChange: (index: Int, award: AwardData) -> Unit,
     onSaveButtonClick: () -> Unit,
 ) {
+    val context = LocalContext.current
     val bottomSheetState =
         rememberModalBottomSheetState(initialValue = ModalBottomSheetValue.Hidden)
     val coroutineScope = rememberCoroutineScope()
@@ -139,9 +141,20 @@ fun MyPageScreen(
         }
     }
 
+    LaunchedEffect(viewModel.myProfileData.value.portfolioUrl, viewModel.myProfileData.value) {
+        when {
+            viewModel.myProfileData.value.portfolioUrl != null -> selectedPortfolioType.value = PortfolioType.URL.text
+            viewModel.myPortfolioPdfData.value != null -> selectedPortfolioType.value = PortfolioType.PDF.text
+            else -> selectedPortfolioType.value = ""
+        }
+    }
+
     LaunchedEffect(viewModel.isProfileChanged.value && viewModel.isProjectIconChanged.value && viewModel.isProjectPreviewChanged.value) {
         if (viewModel.isProfileChanged.value && viewModel.isProjectIconChanged.value && viewModel.isProjectPreviewChanged.value) {
             viewModel.putChangeProfile()
+        }
+        if (selectedPortfolioType.value == PortfolioType.PDF.text && viewModel.pdfData.value != null) {
+            viewModel.putChangedPortfolioPdf(context)
         }
     }
 

--- a/presentation/src/main/java/com/sms/presentation/main/ui/mypage/component/profile/PortfolioComponent.kt
+++ b/presentation/src/main/java/com/sms/presentation/main/ui/mypage/component/profile/PortfolioComponent.kt
@@ -27,7 +27,7 @@ import com.msg.sms.design.modifier.smsClickable
 import com.msg.sms.design.theme.SMSTheme
 import com.msg.sms.design.util.AddGrayBody1Title
 import com.sms.presentation.main.ui.mypage.state.PortfolioType
-import com.sms.presentation.main.ui.util.getFileNameFromUri
+import com.sms.presentation.main.ui.util.getFileName
 
 @Composable
 fun PortfolioComponent(
@@ -93,7 +93,7 @@ fun PortfolioComponent(
                         verticalAlignment = Alignment.CenterVertically
                     ) {
                         Text(
-                            text = if (portfolioPdfValue != null) getFileNameFromUri(context, portfolioPdfValue) ?: ".pdf" else "+ pdf 파일 추가",
+                            text = if (portfolioPdfValue != null) getFileName(context, portfolioPdfValue.toString()) ?: "?.pdf" else "+ pdf 파일 추가",
                             style = typography.body1,
                             fontWeight = FontWeight.Normal,
                             color = if (portfolioPdfValue != null) colors.BLACK else colors.N30

--- a/presentation/src/main/java/com/sms/presentation/main/ui/util/downloadFile.kt
+++ b/presentation/src/main/java/com/sms/presentation/main/ui/util/downloadFile.kt
@@ -1,0 +1,27 @@
+package com.sms.presentation.main.ui.util
+
+import android.content.Context
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.io.File
+import java.io.FileOutputStream
+import java.net.URL
+
+suspend fun downloadFile(context: Context, urlString: String): File? {
+    return withContext(Dispatchers.IO) {
+        try {
+            val url = URL(urlString)
+            val fileName = url.path.substringAfterLast("/")
+            val file = File(context.cacheDir, fileName)
+            url.openStream().use { input ->
+                FileOutputStream(file).use { output ->
+                    input.copyTo(output)
+                }
+            }
+            file
+        } catch (e: Exception) {
+            e.printStackTrace()
+            null
+        }
+    }
+}

--- a/presentation/src/main/java/com/sms/presentation/main/ui/util/getFileName.kt
+++ b/presentation/src/main/java/com/sms/presentation/main/ui/util/getFileName.kt
@@ -1,0 +1,12 @@
+package com.sms.presentation.main.ui.util
+
+import android.content.Context
+import android.net.Uri
+
+fun getFileName(context: Context, input: String): String? {
+    return if (input.startsWith("http://") || input.startsWith("https://")) {
+        getFileNameFromUrl(input)
+    } else {
+        getFileNameFromUri(context, Uri.parse(input))
+    }
+}

--- a/presentation/src/main/java/com/sms/presentation/main/ui/util/getFileNameFromUrl.kt
+++ b/presentation/src/main/java/com/sms/presentation/main/ui/util/getFileNameFromUrl.kt
@@ -1,0 +1,9 @@
+package com.sms.presentation.main.ui.util
+
+import java.net.URLDecoder
+import java.nio.charset.StandardCharsets
+
+fun getFileNameFromUrl(url: String): String {
+    val decodedUrl = URLDecoder.decode(url, StandardCharsets.UTF_8.toString())
+    return decodedUrl.substring(decodedUrl.lastIndexOf('/') + 1)
+}


### PR DESCRIPTION
## 💡 배경 및 개요
- 포트폴리오 파일 업로드 기능구현

## 📃 작업내용
- 포트폴리오 파일 업로드 기능 로직 작성
- 포트폴리오 PDF가 Url인지 로컬 파일인지 구분하여 MultipartBody.Part로 변환
- Url 이면 파일을 다운로드하고 로컬 캐시 디렉토리에 저장 후 로컬 파일 객체를 반환

